### PR TITLE
[feat] 대시보드 품종 별 투입 현황 GET API

### DIFF
--- a/backend/src/main/java/com/poscodx/pofect/domain/dashboard/controller/DashBoardController.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/dashboard/controller/DashBoardController.java
@@ -1,0 +1,32 @@
+package com.poscodx.pofect.domain.dashboard.controller;
+
+import com.poscodx.pofect.common.dto.ResponseDto;
+import com.poscodx.pofect.domain.dashboard.dto.DashBoardInputStatusResDto;
+import com.poscodx.pofect.domain.dashboard.service.DashBoardService;
+import com.poscodx.pofect.domain.essentialstandard.dto.EssentialStandardResDto;
+import com.poscodx.pofect.domain.essentialstandard.service.EssentialStandardService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+@Api(value = "DashBoard API", tags = {"대시보드"})
+@CrossOrigin("*")
+@RequestMapping()
+@RestController
+@RequiredArgsConstructor
+public class DashBoardController {
+    private final DashBoardService dashBoardService;
+    @GetMapping("/input-status")
+    @ApiOperation(value = "품종별 투입 현황 조회", notes = "품종별 투입 현황을 조회한다.")
+    public ResponseEntity<ResponseDto> getInputStatusList() {
+        List<DashBoardInputStatusResDto> result = dashBoardService.getInputStatusList();
+        return new ResponseEntity<>(new ResponseDto(result), HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/com/poscodx/pofect/domain/dashboard/dto/DashBoardInputStatusResDto.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/dashboard/dto/DashBoardInputStatusResDto.java
@@ -1,0 +1,17 @@
+package com.poscodx.pofect.domain.dashboard.dto;
+
+import com.poscodx.pofect.domain.entity.BaseEntity;
+import lombok.*;
+
+import javax.validation.constraints.Size;
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DashBoardInputStatusResDto {
+    @Size(max = 2)
+    private String ordPdtItpCdN;  // 10.주문품종코드
+
+    private int count;
+}

--- a/backend/src/main/java/com/poscodx/pofect/domain/dashboard/service/DashBoardService.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/dashboard/service/DashBoardService.java
@@ -1,0 +1,10 @@
+package com.poscodx.pofect.domain.dashboard.service;
+
+import com.poscodx.pofect.domain.dashboard.dto.DashBoardInputStatusResDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+public interface DashBoardService {
+    List<DashBoardInputStatusResDto> getInputStatusList();
+}

--- a/backend/src/main/java/com/poscodx/pofect/domain/dashboard/service/DashBoardServiceImpl.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/dashboard/service/DashBoardServiceImpl.java
@@ -1,0 +1,37 @@
+package com.poscodx.pofect.domain.dashboard.service;
+
+import com.poscodx.pofect.domain.dashboard.dto.DashBoardInputStatusResDto;
+import com.poscodx.pofect.domain.main.entity.FactoryOrderInfo;
+import com.poscodx.pofect.domain.main.repository.FactoryOrderInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class DashBoardServiceImpl implements DashBoardService{
+    private final FactoryOrderInfoRepository factoryOrderInfoRepository;
+
+    @Override
+    public List<DashBoardInputStatusResDto> getInputStatusList() {
+        List<Object[]> result = factoryOrderInfoRepository.getInputStatus();
+        List<DashBoardInputStatusResDto> dashBoardInputStatusResDtoList = new ArrayList<>();
+
+        for (Object[] array : result) {
+            DashBoardInputStatusResDto dto = new DashBoardInputStatusResDto();
+            if (array.length > 0) {
+                dto.setOrdPdtItpCdN((String) array[0]);
+            }
+            if (array.length > 1) {
+                Long countValue = (Long) array[1];
+                dto.setCount(countValue.intValue());
+            }
+            dashBoardInputStatusResDtoList.add(dto);
+        }
+        return dashBoardInputStatusResDtoList;
+    }
+}

--- a/backend/src/main/java/com/poscodx/pofect/domain/main/repository/FactoryOrderInfoRepository.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/main/repository/FactoryOrderInfoRepository.java
@@ -2,8 +2,13 @@ package com.poscodx.pofect.domain.main.repository;
 
 import com.poscodx.pofect.domain.main.entity.FactoryOrderInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface FactoryOrderInfoRepository extends JpaRepository<FactoryOrderInfo, Long> {
+    @Query("SELECT f.ordPdtItpCdN, COUNT(f) FROM FactoryOrderInfo f GROUP BY f.ordPdtItpCdN")
+    List<Object[]> getInputStatus();
 }


### PR DESCRIPTION
### 목적

- 대시보드 품종 별 투입 현황 GET API 구현
  
### 주요 변경사항
  
- [O] 대시보드 품종 별 투입 현황 GET API 구현  
  
### 리뷰 요청 (없으면 삭제)

- 전반적인 로직이 맞는지 봐주시면 감사하겠습니다
  
### 이슈 (없으면 삭제)
  
- close #27 
