### PR TITLE
[feat] 대시보드 품종 별 주문조회 GET API 구현

### DIFF
--- a/backend/src/main/java/com/poscodx/pofect/domain/dashboard/controller/DashBoardController.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/dashboard/controller/DashBoardController.java
@@ -2,6 +2,7 @@ package com.poscodx.pofect.domain.dashboard.controller;
 
 import com.poscodx.pofect.common.dto.ResponseDto;
 import com.poscodx.pofect.domain.dashboard.dto.DashBoardInputStatusResDto;
+import com.poscodx.pofect.domain.dashboard.dto.DashBoardOrderInquiryResDto;
 import com.poscodx.pofect.domain.dashboard.service.DashBoardService;
 import com.poscodx.pofect.domain.essentialstandard.dto.EssentialStandardResDto;
 import com.poscodx.pofect.domain.essentialstandard.service.EssentialStandardService;
@@ -27,6 +28,13 @@ public class DashBoardController {
     @ApiOperation(value = "품종별 투입 현황 조회", notes = "품종별 투입 현황을 조회한다.")
     public ResponseEntity<ResponseDto> getInputStatusList() {
         List<DashBoardInputStatusResDto> result = dashBoardService.getInputStatusList();
+        return new ResponseEntity<>(new ResponseDto(result), HttpStatus.OK);
+    }
+
+    @GetMapping("/order-inquiry")
+    @ApiOperation(value = "품종별 주문 조회", notes = "품종별 주문 상태를 조회한다.")
+    public ResponseEntity<ResponseDto> getOrderInquiryList() {
+        List<DashBoardOrderInquiryResDto> result = dashBoardService.getOrderInquiry();
         return new ResponseEntity<>(new ResponseDto(result), HttpStatus.OK);
     }
 }

--- a/backend/src/main/java/com/poscodx/pofect/domain/dashboard/dto/DashBoardOrderInquiryResDto.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/dashboard/dto/DashBoardOrderInquiryResDto.java
@@ -1,0 +1,21 @@
+package com.poscodx.pofect.domain.dashboard.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.Size;
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DashBoardOrderInquiryResDto {
+    @Size(max = 2)
+    private String ordPdtItpCdN;  // 10.주문품종코드
+
+    private int countA;
+    private int countB;
+    private int countC;
+    private int countD;
+    private int countE;
+    private int countF;
+}

--- a/backend/src/main/java/com/poscodx/pofect/domain/dashboard/service/DashBoardService.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/dashboard/service/DashBoardService.java
@@ -1,10 +1,13 @@
 package com.poscodx.pofect.domain.dashboard.service;
 
 import com.poscodx.pofect.domain.dashboard.dto.DashBoardInputStatusResDto;
+import com.poscodx.pofect.domain.dashboard.dto.DashBoardOrderInquiryResDto;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 public interface DashBoardService {
     List<DashBoardInputStatusResDto> getInputStatusList();
+    List<DashBoardOrderInquiryResDto> getOrderInquiry();
+
 }

--- a/backend/src/main/java/com/poscodx/pofect/domain/dashboard/service/DashBoardServiceImpl.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/dashboard/service/DashBoardServiceImpl.java
@@ -1,6 +1,7 @@
 package com.poscodx.pofect.domain.dashboard.service;
 
 import com.poscodx.pofect.domain.dashboard.dto.DashBoardInputStatusResDto;
+import com.poscodx.pofect.domain.dashboard.dto.DashBoardOrderInquiryResDto;
 import com.poscodx.pofect.domain.main.entity.FactoryOrderInfo;
 import com.poscodx.pofect.domain.main.repository.FactoryOrderInfoRepository;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +34,25 @@ public class DashBoardServiceImpl implements DashBoardService{
             dashBoardInputStatusResDtoList.add(dto);
         }
         return dashBoardInputStatusResDtoList;
+    }
+
+    @Override
+    public List<DashBoardOrderInquiryResDto> getOrderInquiry() {
+        List<Object[]> result = factoryOrderInfoRepository.getOrderInquiry();
+        List<DashBoardOrderInquiryResDto> dashBoardOrderInquiryResDtoList = new ArrayList<>();
+
+        for (Object[] array : result) {
+            DashBoardOrderInquiryResDto dto = new DashBoardOrderInquiryResDto();
+
+                dto.setOrdPdtItpCdN((String) array[0]);
+                dto.setCountA(Integer.parseInt(array[1].toString()));
+                dto.setCountB(Integer.parseInt(array[2].toString()));
+                dto.setCountC(Integer.parseInt(array[3].toString()));
+                dto.setCountD(Integer.parseInt(array[4].toString()));
+                dto.setCountE(Integer.parseInt(array[5].toString()));
+                dto.setCountF(Integer.parseInt(array[6].toString()));
+                dashBoardOrderInquiryResDtoList.add(dto);
+        }
+        return dashBoardOrderInquiryResDtoList;
     }
 }

--- a/backend/src/main/java/com/poscodx/pofect/domain/main/repository/FactoryOrderInfoRepository.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/main/repository/FactoryOrderInfoRepository.java
@@ -11,4 +11,15 @@ import java.util.List;
 public interface FactoryOrderInfoRepository extends JpaRepository<FactoryOrderInfo, Long> {
     @Query("SELECT f.ordPdtItpCdN, COUNT(f) FROM FactoryOrderInfo f GROUP BY f.ordPdtItpCdN")
     List<Object[]> getInputStatus();
+
+    @Query(value = "SELECT ord_pdt_itp_cd_n, " +
+            "SUM(CASE WHEN FA_CONFIRM_FLAG = 'A' THEN 1 ELSE 0 END) AS A, " +
+            "SUM(CASE WHEN FA_CONFIRM_FLAG = 'B' THEN 1 ELSE 0 END) AS B, " +
+            "SUM(CASE WHEN FA_CONFIRM_FLAG = 'C' THEN 1 ELSE 0 END) AS C, " +
+            "SUM(CASE WHEN FA_CONFIRM_FLAG = 'D' THEN 1 ELSE 0 END) AS D, " +
+            "SUM(CASE WHEN FA_CONFIRM_FLAG = 'E' THEN 1 ELSE 0 END) AS E, " +
+            "SUM(CASE WHEN FA_CONFIRM_FLAG = 'F' THEN 1 ELSE 0 END) AS F " +
+            "FROM factory_order_info " +
+            "GROUP BY ord_pdt_itp_cd_n", nativeQuery = true)
+    List<Object[]> getOrderInquiry();
 }


### PR DESCRIPTION
### 목적

- 대시보드 품종 별 주문조회 GET API 구현
  
### 주요 변경사항
  
- [O] 대시보드 품종 별 주문조회 GET API 구현

### 이슈
  
- close #32 
