### PR TITLE
[sytle] 경유공정기준 page > popup 으로 이동

### DIFF
--- a/frontend/src/navigation/vertical/index.js
+++ b/frontend/src/navigation/vertical/index.js
@@ -40,13 +40,6 @@ const navigation = () => {
       title: "가능/확통 기준",
       path: "/factory-standard",
     },
-
-    {
-      icon: CubeOutline,
-      title: "경유 공정 기준",
-      path: "/pass-standard",
-    },
-
     {
       sectionTitle: "모니터링",
     },

--- a/frontend/src/pages/factory-standard/index.js
+++ b/frontend/src/pages/factory-standard/index.js
@@ -106,28 +106,28 @@ const Capacity = () => {
   },[]);
   //가통 컬럼
   const possibleColumns = [
-    { field: "code",headerName:"Code", width:120, headerAlign: "center"},
-    { field: "10", headerName: "제강", width:120, headerAlign: "center"},
-    { field: "20", headerName: "열연", width:120, headerAlign: "center"},
-    { field: "30", headerName: "열연정정", width:120,  headerAlign: "center"},
-    { field: "40", headerName: "냉간압연", width:120,  headerAlign: "center"},
-    { field: "50", headerName: "1차소둔", width:120,  headerAlign: "center"},
-    { field: "60", headerName: "2차소둔", width:120,  headerAlign: "center"},
-    { field: "70", headerName: "도금", width:120, headerAlign: "center"},
-    { field: "80", headerName: "정정", width:120, headerAlign: "center"},
+    { field: "code",headerName:"Code", width:150, headerAlign: "center"},
+    { field: "10", headerName: "제강", width:150, headerAlign: "center"},
+    { field: "20", headerName: "열연", width:150, headerAlign: "center"},
+    { field: "30", headerName: "열연정정", width:150,  headerAlign: "center"},
+    { field: "40", headerName: "냉간압연", width:150,  headerAlign: "center"},
+    { field: "50", headerName: "1차소둔", width:150,  headerAlign: "center"},
+    { field: "60", headerName: "2차소둔", width:150,  headerAlign: "center"},
+    { field: "70", headerName: "도금", width:150, headerAlign: "center"},
+    { field: "80", headerName: "정정", width:150, headerAlign: "center"},
   ];
 
   //확통 컬럼
   const confirmColumns=[
-    { field: "code",headerName:"Code", width:120, headerAlign: "center"   },
-    { field: "10", headerName: "제강", width:120, headerAlign: "center"    },
-    { field: "20", headerName: "열연", width:120, headerAlign: "center"     },
-    { field: "30", headerName: "열연정정", width:120,headerAlign: "center"  },
-    { field: "40", headerName: "냉간압연", width:120,headerAlign: "center"  },
-    { field: "50", headerName: "1차소둔", width:120, headerAlign: "center"  },
-    { field: "60", headerName: "2차소둔", width:120, headerAlign: "center"  },
-    { field: "70", headerName: "도금", width:120, headerAlign: "center"     },
-    { field: "80", headerName: "정정", width:120, headerAlign: "center"     },
+    { field: "code",headerName:"Code", width:150, headerAlign: "center"   },
+    { field: "10", headerName: "제강", width:150, headerAlign: "center"    },
+    { field: "20", headerName: "열연", width:150, headerAlign: "center"     },
+    { field: "30", headerName: "열연정정", width:150,headerAlign: "center"  },
+    { field: "40", headerName: "냉간압연", width:150,headerAlign: "center"  },
+    { field: "50", headerName: "1차소둔", width:150, headerAlign: "center"  },
+    { field: "60", headerName: "2차소둔", width:150, headerAlign: "center"  },
+    { field: "70", headerName: "도금", width:150, headerAlign: "center"     },
+    { field: "80", headerName: "정정", width:150, headerAlign: "center"     },
   ]
   let pPopupProcessCd=null;
   let feasibleArray = null;

--- a/frontend/src/pages/factory-standard/index.js
+++ b/frontend/src/pages/factory-standard/index.js
@@ -4,11 +4,46 @@ import Popper from '@mui/material/Popper';
 import Fade from '@mui/material/Fade';
 import Paper from '@mui/material/Paper';
 import PossibleDetail from "./possible-detail";
+import PassModal from './pass-modal';
 
 import "react-datasheet-grid/dist/style.css";
-import { Grid, Typography, Button, Select, MenuItem, FormControl, InputLabel, OutlinedInput, accordionActionsClasses, Card, Box } from "@mui/material";
+import { Grid, Typography, 
+          Button, Select, MenuItem, FormControl, 
+          InputLabel, OutlinedInput,
+          Card, Box, Dialog,
+          DialogTitle,DialogContent,
+          DialogContentText,DialogActions } from "@mui/material";
 import FactoryStandardApi from "src/api/FactoryStandardApi";
 
+
+function MyCell(props) {
+  let style = {
+    minWidth: props.width,
+    maxWidth: props.width,
+    minHeight: props.height,
+    maxHeight: props.height === "auto" ? "none" : props.height,
+    ...props.style,
+    //중앙배열
+    display: "flex",
+    alignItems: "center",
+    headerAlign: 'center',
+    justifyContent: "center",
+  };
+  const apiRef = useGridApiContext();
+  const row = apiRef.current.getRow(props.rowId);
+
+  if (row && row.rowSpan && row.rowSpan[props.column.field]) {
+    const span = row.rowSpan[props.column.field];
+    style = {
+      ...style,
+      minHeight: props.height * span,
+      maxHeight: props.height * span,
+      backgroundColor: "gray",
+      zIndex: 1,
+    };
+  }
+  return <GridCell {...props} style={style} />;
+}
 
 const Capacity = () => {
   /* Data */
@@ -18,11 +53,19 @@ const Capacity = () => {
   const [open, setOpen] = useState(false); //가통Popper오픈
   const [anchorEl, setAnchorEl] = useState(null);//Popper
   const [placement, setPlacement] = useState();//Popper위치
+  const [openPassStandard, setOpenPassStandard] = useState(false);
+
   const [a,setA] = useState({
     processCd:null,
     processFacNum:null
   })
+  const passClick = () => {
+    setOpenPassStandard(true);
+  };
 
+  const passClose = () => {
+    setOpenPassStandard(false);
+  };
   const openFun= (check)=>{
     setOpen(check)
   }
@@ -152,9 +195,10 @@ const Capacity = () => {
         </FormControl>
       </div>
         <div>
-          <Button size="small" type="submit" variant="contained">
-            경유공정
+          <Button size="small" type="submit" variant="contained" onClick={passClick}>
+          경유공정
           </Button>
+          <PassModal open={openPassStandard} handleClose={passClose} />
           <Button size="small" type="submit" variant="contained">
             조회
           </Button>
@@ -197,12 +241,11 @@ const Capacity = () => {
             onDoubleClick:openPossibleOne,
           },
         }}
-        // onCellClick={(e) => {
-          
-        //   setPossibleList(e);
-        //   console.log('소구분 : '+e);
-        // }}
+        slots={{
+          cell: MyCell,
+        }}
         hideFooter = {true}
+        
       /></Box>
       </Card>
       
@@ -250,9 +293,10 @@ const Capacity = () => {
         //disableRowSelectionOnClick
         rows={confirmList}
         columns={confirmColumns}
-
         hideFooter = {true}last
-
+        slots={{
+          cell: MyCell,
+        }}
       /></Box>
       </Card>
       </div>

--- a/frontend/src/pages/factory-standard/pass-modal.js
+++ b/frontend/src/pages/factory-standard/pass-modal.js
@@ -1,0 +1,251 @@
+// pass-standard/pass-modal.js
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Card,
+  Grid,
+  Typography,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  OutlinedInput,
+  Button
+} from "@mui/material";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button as MuiButton, // Rename Button to MuiButton to avoid conflict
+} from '@mui/material';
+import "react-datasheet-grid/dist/style.css";
+import "ag-grid-community/styles/ag-grid.css";
+import "ag-grid-community/styles/ag-theme-alpine.css";
+import { GridToolbar } from "@mui/x-data-grid";
+import { DataGrid, GridCell, useGridApiContext } from "@mui/x-data-grid";
+import PassStandardApi from "src/api/PassStandardApi";
+
+function MyCell(props) {
+  let style = {
+    minWidth: props.width,
+    maxWidth: props.width,
+    minHeight: props.height,
+    maxHeight: props.height === "auto" ? "none" : props.height,
+    ...props.style,
+    //중앙배열
+    display: "flex",
+    alignItems: "center",
+    headerAlign: 'center',
+    justifyContent: "center",
+  };
+  const apiRef = useGridApiContext();
+  const row = apiRef.current.getRow(props.rowId);
+
+  if (row && row.rowSpan && row.rowSpan[props.column.field]) {
+    const span = row.rowSpan[props.column.field];
+    style = {
+      ...style,
+      minHeight: props.height * span,
+      maxHeight: props.height * span,
+      backgroundColor: "gray",
+      zIndex: 1,
+    };
+  }
+  return <GridCell {...props} style={style} />;
+}
+
+const PassModal = ({ open, handleClose }) => {
+  const [passStandard, setPassStandard] = useState([]);
+  const [selectCodeName, setSelectCodeName] = useState("FS");
+  const [codeNameList, setCodeNameList] = useState([]);
+
+  useEffect(() => {
+    PassStandardApi.getList((data) => {
+      setPassStandard(data.response);
+    });
+    PassStandardApi.getCodeNameList((data) => {
+      setCodeNameList(data.response);
+    });
+  }, []);
+
+  //   const uniqueWeekCodes = [...new Set(week.map((item) => item.ordThwTapWekCd))];
+  // const handleWeekSelectChange = (e) => {
+  //   console.log(e);
+  // };
+  const columns = [
+    { field: "ordPdtItdsCdN", headerName: "품명", width: 130, headerAlign: 'center', headerClassName: 'custom-header', style: { borderRight: '1px solid #ccc', paddingRight: '8px' }, editable: true },
+    { field: "availablePassFacCdN1", headerName: "제강", width: 100, headerAlign: 'center', headerClassName: 'custom-header', style: { borderRight: '1px solid #ccc', paddingRight: '8px' }, editable: true },
+    { field: "availablePassFacCdN2", headerName: "열연", width: 100, headerAlign: 'center', headerClassName: 'custom-header', style: { borderRight: '1px solid #ccc', paddingRight: '8px' }, editable: true },
+    { field: "availablePassFacCdN3", headerName: "열연정정", width: 100, headerAlign: 'center', headerClassName: 'custom-header', style: { borderRight: '1px solid #ccc', paddingRight: '8px' }, editable: true },
+    { field: "availablePassFacCdN4", headerName: "냉연", width: 100, headerAlign: 'center', headerClassName: 'custom-header', style: { borderRight: '1px solid #ccc', paddingRight: '8px' }, editable: true },
+    { field: "availablePassFacCdN5", headerName: "1차소둔", width: 100, headerAlign: 'center', headerClassName: 'custom-header', style: { borderRight: '1px solid #ccc', paddingRight: '8px' }, editable: true },
+    { field: "availablePassFacCdN6", headerName: "2차소둔", width: 100, headerAlign: 'center', headerClassName: 'custom-header', style: { borderRight: '1px solid #ccc', paddingRight: '8px' }, editable: true },
+    { field: "availablePassFacCdN7", headerName: "도금", width: 100, headerAlign: 'center', headerClassName: 'custom-header', style: { borderRight: '1px solid #ccc', paddingRight: '8px' }, editable: true },
+    { field: "availablePassFacCdN8", headerName: "정정", width: 100, headerAlign: 'center', headerClassName: 'custom-header', style: { borderRight: '1px solid #ccc', paddingRight: '8px' }, editable: true },
+  ];
+
+
+  return (
+    <Dialog open={open} onClose={handleClose} sx={{ width: '100%'}} maxWidth="xl">
+      <div style={{maxWidth:'1200px'}}>
+      <DialogTitle>
+      <Grid item xs={12} sx={{ paddingBottom: 4 }}>
+          {/* <Card></Card> */}
+          <Typography variant="h3">경유 공정 기준</Typography>
+        </Grid>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          {/* ./pass-standard/index.js 파일 내용 또는 원하는 모달 내용을 여기에 추가 */}
+          <divdafdsfads
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: "20px",
+          }}
+        >
+          <div>
+            <FormControl
+              sx={{ m: 1 }}
+              style={{
+                paddingTop: 10,
+                paddingBottom: 20,
+                marginRight: 10,
+              }}>
+              <InputLabel id="label1" style={{ paddingTop: 10 }}>
+                품종
+              </InputLabel>
+              <Select
+                labelId="분류"
+                id="demo-multiple-name"
+                defaultValue="T"
+                input={<OutlinedInput label="구분" />}
+                onChange={(e) => {
+                  console.log(e);
+                }}
+                style={{ height: 40 }}
+              >
+                <MenuItem value="T">포항</MenuItem>
+                {/* <MenuItem value="K">광양</MenuItem> */}
+              </Select>
+            </FormControl>
+            <FormControl
+              sx={{ m: 1 }}
+              style={{
+                paddingTop: 10,
+                paddingBottom: 20,
+                marginRight: 10,
+              }}
+            >
+              <InputLabel id="label2" style={{ paddingTop: 10 }}>
+                품종
+              </InputLabel>
+
+              <Select
+                labelId="분류"
+                id="demo-multiple-name"
+                defaultValue="FS"
+                input={<OutlinedInput label="품종" />}
+                onChange={(e) => {
+                  setSelectCodeName(e.target.value);
+                }}
+                style={{ height: 40 }}
+              >
+                {codeNameList.map((code, idx) => {
+                  return (
+                    <MenuItem key={idx} value={code.cdNm}>
+                      {code.cdNm}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            </FormControl>
+          </div>
+          <div>
+
+            <Button size="small" type="submit" variant="contained">
+              조회
+            </Button>
+            <Button size="small" type="submit" variant="contained">
+              저장
+            </Button>
+            <Button size="small" type="submit" variant="contained">
+              Excel
+            </Button>
+          </div>
+        </divdafdsfads>
+        <div style={{ height: 400, display: "flex", justifyContent: "center", marginTop: 30, }}>
+          <Card
+            elevation={3}
+            style={{
+              flexBasis: "85",
+              marginRight: "16px ",
+              padding: "20px",
+              height: "100%",
+
+            }}
+          >
+            <Box
+              sx={{
+                height: "100%",
+                width: "100%",
+                marginBottom: "20px",
+                "& .custom-data-grid .MuiDataGrid-columnsContainer, & .custom-data-grid .MuiDataGrid-cell":
+                {
+                  borderBottom: "1px solid rgba(225, 234, 239, 1)",
+                  borderRight: "1px solid rgba(225, 234, 239, 1)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                },
+                "& .custom-data-grid .MuiDataGrid-columnHeader": {
+                  cursor: "pointer",
+                  borderBottom: "1px solid rgba(225, 234, 239, 1)",
+                  borderRight: "1px solid rgba(225, 234, 239, 1)",
+                },
+                "& .custom-data-grid .MuiDataGrid-columnHeader--filledGroup  .MuiDataGrid-columnHeaderTitleContainer":
+                {
+                  borderBottomStyle: "none",
+                },
+
+                "& .custom-data-grid .MuiDataGrid-root": {
+                  paddingBottom: "0px",
+                },
+              }}
+            >
+              <DataGrid
+                className="custom-data-grid"
+
+                disableRowSelectionOnClick
+                rows={passStandard}
+                columns={columns}
+                onCellClick={(e) => {
+                  console.log(e);
+                }}
+                components={{
+                  Toolbar: GridToolbar,
+                  Cell: MyCell,
+                }}
+                rowHeight={31}
+
+              />
+            </Box>
+          </Card>
+        </div>
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color="primary">
+          닫기
+        </Button>
+      </DialogActions>
+      </div>
+    </Dialog>
+  );
+};
+
+export default PassModal;


### PR DESCRIPTION
### 목적

- 경유공정기준을 원래의 개발 조건과 맞춰 팝업으로 이동
  
### 주요 변경사항
  
- [x] 네비게이션 바에서 경유공정기준 삭제
- [x] 구분에서 광양 삭제
- [x] 가능/확통기준 의 버튼을 누르면 경유공정 팝업 나오도록 변경
  
### 이슈
- 경유공정기준 세지가 만든 페이지 :  http://localhost:3000/pass-standard/ 에 들어가면 볼 수 있고, 네비바에서는 지웠습니다.

close #109 
