### PR TITLE
[feat]가통코드로 확통 공장 번호 반환

### DIFF
--- a/backend/src/main/java/com/poscodx/pofect/domain/essentialstandard/controller/EssentialStandardController.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/essentialstandard/controller/EssentialStandardController.java
@@ -6,6 +6,7 @@ import com.poscodx.pofect.domain.essentialstandard.dto.EssentialStandardResDto;
 import com.poscodx.pofect.domain.essentialstandard.service.EssentialStandardService;
 import com.poscodx.pofect.domain.main.controller.MainController;
 import com.poscodx.pofect.domain.main.dto.FactoryOrderInfoResDto;
+import com.poscodx.pofect.domain.passstandard.controller.PossibleFactoryStandardController;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,7 @@ import java.util.List;
 public class EssentialStandardController {
     private final EssentialStandardService essentialStandardService;
     private final MainController mainController;
-
+   // private final PossibleFactoryStandardController possibleFactoryStandardController;
     @GetMapping("/essential-standard")
     @ApiOperation(value = "필수재 기준 조회", notes = "필수재 기준을 조회한다.")
     public ResponseEntity<ResponseDto> getEssentialStandardList() {
@@ -39,6 +40,7 @@ public class EssentialStandardController {
         ResponseEntity<ResponseDto> responseEntity = mainController.getOrderById(id);
         FactoryOrderInfoResDto factoryInfo = (FactoryOrderInfoResDto) responseEntity.getBody().getResponse();
         List<EssentialStandardBtiPosReqDto> essentialStandardBtiPosReqDtoList = essentialStandardService.applyEssentialStandard(factoryInfo,processList);
+//        possibleFactoryStandardController.getPossibleToConfirm(essentialStandardBtiPosReqDtoList);
         return essentialStandardBtiPosReqDtoList;
     }
 

--- a/backend/src/main/java/com/poscodx/pofect/domain/essentialstandard/controller/EssentialStandardController.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/essentialstandard/controller/EssentialStandardController.java
@@ -24,7 +24,6 @@ import java.util.List;
 public class EssentialStandardController {
     private final EssentialStandardService essentialStandardService;
     private final MainController mainController;
-   // private final PossibleFactoryStandardController possibleFactoryStandardController;
     @GetMapping("/essential-standard")
     @ApiOperation(value = "필수재 기준 조회", notes = "필수재 기준을 조회한다.")
     public ResponseEntity<ResponseDto> getEssentialStandardList() {
@@ -40,7 +39,6 @@ public class EssentialStandardController {
         ResponseEntity<ResponseDto> responseEntity = mainController.getOrderById(id);
         FactoryOrderInfoResDto factoryInfo = (FactoryOrderInfoResDto) responseEntity.getBody().getResponse();
         List<EssentialStandardBtiPosReqDto> essentialStandardBtiPosReqDtoList = essentialStandardService.applyEssentialStandard(factoryInfo,processList);
-//        possibleFactoryStandardController.getPossibleToConfirm(essentialStandardBtiPosReqDtoList);
         return essentialStandardBtiPosReqDtoList;
     }
 

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/controller/PossibleFactoryStandardController.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/controller/PossibleFactoryStandardController.java
@@ -1,7 +1,10 @@
 package com.poscodx.pofect.domain.passstandard.controller;
 
 import com.poscodx.pofect.common.dto.ResponseDto;
+import com.poscodx.pofect.domain.essentialstandard.dto.EssentialStandardBtiPosReqDto;
+import com.poscodx.pofect.domain.main.dto.FactoryOrderInfoResDto;
 import com.poscodx.pofect.domain.passstandard.dto.PossibleFactoryStandardResDto;
+import com.poscodx.pofect.domain.passstandard.dto.PossibleToConfirmResDto;
 import com.poscodx.pofect.domain.passstandard.repository.PossibleFactoryStandardRepository;
 import com.poscodx.pofect.domain.passstandard.service.PossibleFactoryStandardService;
 import io.swagger.annotations.Api;
@@ -9,10 +12,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -30,4 +30,13 @@ public class PossibleFactoryStandardController {
         List<PossibleFactoryStandardResDto> result = possibleFactoryStandardService.getGridData();
         return new ResponseEntity<>(new ResponseDto(result), HttpStatus.OK);
     }
+
+    @PostMapping("/possibleToConfirm")
+    @ApiOperation(value="필수재에서 받은 가통코드를 확통 공장 번호 변환", notes="가통 코드 > 확통 공장 번호")
+    public ResponseEntity<ResponseDto> getPossibleToConfirm(@RequestBody List<EssentialStandardBtiPosReqDto> essentialStandardBtiPosReqDtoList){
+        List<PossibleToConfirmResDto> result = possibleFactoryStandardService.possibleToConfirm(essentialStandardBtiPosReqDtoList);
+
+        return new ResponseEntity<>(new ResponseDto(result), HttpStatus.OK);
+    }
+
 }

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/dto/PossibleFactoryStandardResDto.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/dto/PossibleFactoryStandardResDto.java
@@ -54,5 +54,4 @@ public class PossibleFactoryStandardResDto {
                 .feasibleRoutingGroup(possibleFactoryStandard[2].toString())
                 .build();
     }
-
 }

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/dto/PossibleToConfirmResDto.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/dto/PossibleToConfirmResDto.java
@@ -1,0 +1,17 @@
+package com.poscodx.pofect.domain.passstandard.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PossibleToConfirmResDto {
+    private String processCD;
+    private List<String> firmPsFacTpList;
+}

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/repository/PossibleFactoryStandardRepository.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/repository/PossibleFactoryStandardRepository.java
@@ -1,6 +1,6 @@
 package com.poscodx.pofect.domain.passstandard.repository;
 
-import com.poscodx.pofect.domain.passstandard.dto.PossibleFactoryStandardResDto;
+import com.poscodx.pofect.domain.passstandard.dto.PossibleToConfirmResDto;
 import com.poscodx.pofect.domain.passstandard.entity.PossibleFactoryStandard;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,4 +21,14 @@ public interface PossibleFactoryStandardRepository extends JpaRepository<Possibl
             "ORDER BY " +
             "bti_posb_ps_fac_tp",nativeQuery = true)
     List<Object[]> getGridData();
+
+    @Query(value=
+            "SELECT " +
+            " pfs.feasible_routing_group AS firmPsFacTp " +
+            "FROM " +
+            "    possible_factory_standard pfs " +
+            "WHERE " +
+            "    pfs.process_cd = :processCD AND pfs.bti_posb_ps_fac_tp = :btiPosbPsFacTp"
+            ,nativeQuery = true)
+    String getPossibleToConfirm(String processCD, String btiPosbPsFacTp);
 }

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/service/PossibleFactoryStandardService.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/service/PossibleFactoryStandardService.java
@@ -1,6 +1,8 @@
 package com.poscodx.pofect.domain.passstandard.service;
 
+import com.poscodx.pofect.domain.essentialstandard.dto.EssentialStandardBtiPosReqDto;
 import com.poscodx.pofect.domain.passstandard.dto.PossibleFactoryStandardResDto;
+import com.poscodx.pofect.domain.passstandard.dto.PossibleToConfirmResDto;
 import com.poscodx.pofect.domain.passstandard.entity.PossibleFactoryStandard;
 
 import java.util.List;
@@ -9,4 +11,6 @@ public interface PossibleFactoryStandardService {
 //    List<PossibleFactoryStandardResDto> getList();
 
     List<PossibleFactoryStandardResDto> getGridData();
+
+    List<PossibleToConfirmResDto> possibleToConfirm(List<EssentialStandardBtiPosReqDto> essentialStandardBtiPosReqDtoList);
 }

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/service/PossibleFactoryStandardServiceImpl.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/service/PossibleFactoryStandardServiceImpl.java
@@ -1,10 +1,15 @@
 package com.poscodx.pofect.domain.passstandard.service;
 
+import com.poscodx.pofect.domain.essentialstandard.dto.EssentialStandardBtiPosReqDto;
+import com.poscodx.pofect.domain.essentialstandard.dto.EssentialStandardResDto;
 import com.poscodx.pofect.domain.passstandard.dto.PossibleFactoryStandardResDto;
+import com.poscodx.pofect.domain.passstandard.dto.PossibleToConfirmResDto;
 import com.poscodx.pofect.domain.passstandard.repository.PossibleFactoryStandardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,4 +31,33 @@ public class PossibleFactoryStandardServiceImpl implements PossibleFactoryStanda
                 .map(PossibleFactoryStandardResDto::toDto)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public List<PossibleToConfirmResDto> possibleToConfirm(List<EssentialStandardBtiPosReqDto> essentialStandardBtiPosReqDtoList){
+        List<PossibleToConfirmResDto> result=new ArrayList<>();
+        for(EssentialStandardBtiPosReqDto d:essentialStandardBtiPosReqDtoList){
+            List<PossibleToConfirmResDto> list=new ArrayList<>();
+            System.out.println(d.getProcessCD()+", "+d.getBtiPosbPsFacTpList());
+            HashSet<String> firmPsFacTp = new HashSet<>(); //hash로 공장값 저장 (중복X)
+            PossibleToConfirmResDto.PossibleToConfirmResDtoBuilder builder = PossibleToConfirmResDto.builder();
+            // processCD 설정
+            builder.processCD(d.getProcessCD());
+            for(String btiPosbPsFacTp:d.getBtiPosbPsFacTpList()){
+                // PossibleFactoryStandardResDto를 생성하고 processCD와 firmPsFacTp를 설정
+                //query를 통해 해당 공장 반환
+                String getPossibleToConfirm = possibleFactoryStandardRepository.getPossibleToConfirm(d.getProcessCD(),btiPosbPsFacTp);
+                if(getPossibleToConfirm!=null) {
+                    for (String f : getPossibleToConfirm.split("")) {
+                        System.out.print(f + " ");
+                        firmPsFacTp.add(f);
+                    }
+                    builder.firmPsFacTpList(new ArrayList<>(firmPsFacTp));
+                }
+            }
+            // 리스트에 PossibleToConfirmResDto 객체 추가
+            result.add(builder.build());
+        }
+        return  result;
+    }
+
 }


### PR DESCRIPTION
### 목적

- 필수재기준, 공장결정에서 사용하는 가통코드 > 확통 공장번호 변환 후 반환
  
### 주요 변경사항
  
- [x] PossibleToConfirmResDto 작성
- [x] NativeQuery로 각 공정별 해당공장 가져와서 서비스에서 List처리  

### 리뷰사항
Swagger
가통확통기준 / 가통조회 > 필수재에서 받은 가통코드를 확통 공장 번호 변환 에서 확인하시면 됩니다


close #152 