### PR TITLE
[feat]엑셀 다운로드 기능에서 데이터 순서 변경 및 헤더 한글 적용

### DIFF
--- a/frontend/src/pages/factory-standard/index.js
+++ b/frontend/src/pages/factory-standard/index.js
@@ -159,33 +159,66 @@ const Capacity = () => {
       setOpen(false);
     }
   }
+  // 한글 헤더 매핑 (엑셀용)
+  const koreanHeaderMap = {
+    "id": "Code",
+    "10": "제강",
+    "20": "열연",
+    "30": "열연정정",
+    "40": "냉간압연",
+    "50": "1차소둔",
+    "60": "2차소둔",
+    "70": "도금",
+    "80": "정정",
+  };
 
   const fileType =
     "application/vnd.openxmlformats-officedcoument.spreadsheetml.sheet;charset=UTF-8";
   const fileExtension = ".xlsx";
 
   const exportToExcelPossible = async () => {
-      // 헤더 순서
-    const header = ["id", "10", "20", "30", "40", "50", "60", "70", "80"];
+    //   // 헤더 순서
+    // const header = ["id", "10", "20", "30", "40", "50", "60", "70", "80"];
+
+    // // possibleList의 id를 기준으로 정렬
+    // const sortedPossibleList = [...possibleList].sort((a, b) => a.id - b.id);
+
+    // // 데이터를 헤더와 일치하는 형식으로 변환
+    // const excelData = sortedPossibleList.map(item => header.map(key => item[key]));
+
+    // // 헤더와 데이터를 함께 전달하여 엑셀 생성
+    // const ws = XLSX.utils.aoa_to_sheet([header, ...excelData]);
+    // const wb = { Sheets: { data: ws }, SheetNames: ["data"] };
+    // const excelBuffer = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+    // const data = new Blob([excelBuffer], { type: fileType });
+    // FileSaver.saveAs(data, "가능통과공장기준" + fileExtension);
+    // 헤더 순서
+    const originalHeader = ["id", "10", "20", "30", "40", "50", "60", "70", "80"];
 
     // possibleList의 id를 기준으로 정렬
     const sortedPossibleList = [...possibleList].sort((a, b) => a.id - b.id);
 
     // 데이터를 헤더와 일치하는 형식으로 변환
-    const excelData = sortedPossibleList.map(item => header.map(key => item[key]));
+    const excelData = sortedPossibleList.map(item => originalHeader.map(key => item[key]));
+
+    // 헤더를 한글로 변경
+    const koreanHeader = originalHeader.map(englishKey => koreanHeaderMap[englishKey] || englishKey);
 
     // 헤더와 데이터를 함께 전달하여 엑셀 생성
-    const ws = XLSX.utils.aoa_to_sheet([header, ...excelData]);
+    const ws = XLSX.utils.aoa_to_sheet([koreanHeader, ...excelData]);
     const wb = { Sheets: { data: ws }, SheetNames: ["data"] };
     const excelBuffer = XLSX.write(wb, { bookType: "xlsx", type: "array" });
     const data = new Blob([excelBuffer], { type: fileType });
     FileSaver.saveAs(data, "가능통과공장기준" + fileExtension);
   };
   const exportToExcelConfirm = async () => {
-    const header = ["id", "10", "20", "30", "40", "50", "60", "70", "80"];
+    const originalHeader = ["id", "10", "20", "30", "40", "50", "60", "70", "80"];
     const sortedConfirmList = [...confirmList].sort((a, b) => a.id - b.id);
-    const excelData = sortedConfirmList.map(item => header.map(key => item[key]));
-    const ws = XLSX.utils.aoa_to_sheet([header, ...excelData]);
+    const excelData = sortedConfirmList.map(item => originalHeader.map(key => item[key]));
+    // 헤더를 한글로 변경
+    const koreanHeader = originalHeader.map(englishKey => koreanHeaderMap[englishKey] || englishKey);
+
+    const ws = XLSX.utils.aoa_to_sheet([koreanHeader, ...excelData]);
     const wb = { Sheets: { data: ws }, SheetNames: ["data"] };
     const excelBuffer = XLSX.write(wb, { bookType: "xlsx", type: "array" });
     const data = new Blob([excelBuffer], { type: fileType });

--- a/frontend/src/pages/factory-standard/possible-detail.js
+++ b/frontend/src/pages/factory-standard/possible-detail.js
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { DataGrid, GridCell, useGridApiContext } from "@mui/x-data-grid";
-import { Grid, Typography, Button, Select, MenuItem, FormControl, InputLabel, OutlinedInput, accordionActionsClasses, Card,Box } from "@mui/material";
+import { Grid, Typography, Button, Select, MenuItem, FormControl, 
+  InputLabel, OutlinedInput, accordionActionsClasses, Card,Box,
+  Table, TableBody, TableCell, TableContainer, TableRow, TableHead } 
+from "@mui/material";
 import FactoryStandardApi from 'src/api/FactoryStandardApi';
 
 const possibleDetail =({a,openFun})=>{
@@ -24,7 +27,6 @@ const possibleDetail =({a,openFun})=>{
   }
   const [processFactoryList,setProcessFactoryList]=useState([]);//공정별 리스트
   
-
   useEffect(()=>{
     FactoryStandardApi.getPossiblePopper(a.processCd,(data)=>{
       console.log(data.response);
@@ -52,7 +54,7 @@ const possibleDetail =({a,openFun})=>{
   ]
   return (
     <>
-      <div style={{backgroundColor:"#05507d",color:"white",padding:"0px",fontSize:"20px"}}>코드상세</div>
+      {/*<div style={{backgroundColor:"#05507d",color:"white",padding:"0px",fontSize:"20px"}}>코드상세</div>
       <div>
           <Button size="small" type="submit" variant="contained">
             저장
@@ -95,7 +97,26 @@ const possibleDetail =({a,openFun})=>{
         />
         </Box>
       </Card>
-      </div>
+      </div>*/}
+      <TableContainer>
+        <Table aria-label="spanning table">
+          <TableHead>
+            <TableRow>
+              <TableCell
+                align="center"
+                style={{
+                  width: "100%",
+                  backgroundColor: "#05507d",
+                  color: "white",
+                  fontSize:"20px"
+                }}
+              >
+                코드상세
+              </TableCell>
+            </TableRow>
+          </TableHead>
+        </Table>
+      </TableContainer>
     </>
   );
 }


### PR DESCRIPTION
### 목적

- 가통/확통기준에서는 가공된 데이터를 뿌리기 때문에 엑셀 다운로드 시 표와 그대로 일치하지 않게 가져온다는 문제점 해결
- 헤더가 id이름이라서 , 한글로 보기 좋게 변경
-
### 주요 변경사항
  
- [x] 엑셀 컬럼 순서 지정 (가통/확통 둘다)
- [x] 엑셀 한글 header명 지정 (가통/확통 둘다)
  
### 리뷰 요청 (없으면 삭제)

- 엑셀 다운로드시 컬럼명 한글로 지정하고 싶으면 제 코드 참고해주세요! pages/factory-standard/index.js
