### PR TITLE
[feat]가능확통기준 가통Popper checked 가능하도록 변경

### DIFF
--- a/frontend/src/api/FactoryStandardApi.js
+++ b/frontend/src/api/FactoryStandardApi.js
@@ -15,7 +15,6 @@ const FactoryStandardApi={
     await axiosApi()
     .get(`/factory-standard/confirmfactory/${processCD}`)
     .then((response)=>{
-      console.log(response)
       callback && callback(response.data);
     })
     .catch((error)=>{
@@ -32,6 +31,18 @@ const FactoryStandardApi={
       console.log(error);
     })
     .finally(()=>{});
+  },
+  updatePossibleFactory:async(processCd,checkedList)=>{
+    await axiosApi().patch("/factory-standard/updatePossibleFactory",{
+      processCd:processCd,
+      checkedList:checkedList,
+    })
+    .then((response) => {
+      callback && callback(response.data);
+    })
+    .catch((error) => {
+      console.log(error);
+    });
   },
 }
 

--- a/frontend/src/pages/factory-standard/possible-detail.js
+++ b/frontend/src/pages/factory-standard/possible-detail.js
@@ -27,11 +27,45 @@ const possibleDetail =({a,openFun})=>{
   }
   const [processFactoryList,setProcessFactoryList]=useState([]);//공정별 리스트
   const isSelected=2;
+  const [checkedItemList,setCheckedItemList]=useState([]);//check여부 리스트 
+  const setInitialData=null;
+
   useEffect(() => {
     FactoryStandardApi.getPossiblePopper(a.processCd, (data) => {
-      setProcessFactoryList(data.response);
+      setProcessFactoryList(data.response);//Table에 보여줄 리스트 세팅
+      const initialCheckedItems = data.response.map((item) => item.firmPsFacTp);
+      //processFacNum값이 초기 세팅된 값이므로 setCheckedItemList에 세팅
+      setCheckedItemList(a.processFacNum.map(String));
     }, []);
-  }, []);
+  }, [a.processFacNum]);
+
+  const handleCheckboxChange = (event, firmPsFacTp) => {
+    console.log('Checkbox clicked!', event.target.checked, ' , 현재 체크된 번호 : ',firmPsFacTp);
+    const updatedCheckedItemList = [...checkedItemList];
+    if (event.target.checked) {
+      // 체크가 되어 있지 않으면 추가
+      updatedCheckedItemList.push(firmPsFacTp);
+    } else {
+      // 체크가 해제되면 제거
+      const index = updatedCheckedItemList.indexOf(firmPsFacTp);
+      if (index !== -1) {
+        updatedCheckedItemList.splice(index, 1);
+      }
+    }
+    // 상태 업데이트
+    setCheckedItemList(updatedCheckedItemList);
+  };
+
+  const saveCheck=()=>{
+    console.log('Checked Item List 🔽');
+    console.log(checkedItemList)
+    console.log('processCd = '+a.processCd);
+    const savePossibleFactory=async()=>{
+      await FactoryStandardApi.updatePossibleFactory(a.processCd,checkedItemList,(data)=>{
+        console.log(data);
+      })
+    }
+  }
 
   const processColumn = [
     { field:'isSelected', headerName:isSelected, hidden:true},
@@ -101,9 +135,8 @@ const possibleDetail =({a,openFun})=>{
                 </TableCell>
                 <TableCell padding="checkbox" style={{width:"20%"}}>
                   <Checkbox
-                    checked={
-                      a.processFacNum.includes(Number(e.firmPsFacTp))?true:false
-                    }                                                                                    
+                    checked={checkedItemList.includes(e.firmPsFacTp)}
+                    onChange={(event) => handleCheckboxChange(event, e.firmPsFacTp)}                                                                                    
                     style={{margin:0,padding:0}}
                   />
                 </TableCell>
@@ -121,7 +154,13 @@ const possibleDetail =({a,openFun})=>{
           <TableHead>
             <TableRow align="right" style={{width:"400px"}}>
               <TableCell style={{padding:0, margin:0}}> 
-                <Button size="small" type="submit" variant="contained" style={{ backgroundColor: "#0A5380",color:"white" }}>
+                <Button 
+                  size="small" 
+                  type="submit" 
+                  variant="contained" 
+                  style={{ backgroundColor: "#0A5380",color:"white" }}
+                  onClick={()=>saveCheck()}
+                >
                 저장
               </Button>
               </TableCell>


### PR DESCRIPTION
### 목적

- 가통 popper 저장기능 front 변경!
  
### 주요 변경사항
  
- [x] possible-detail.js checked 변경 가능하도록 설정
- [x] popper에서 저장버튼 클릭시 patch API로 연결되도록 설정 
- [x] api/FactoryStandardApi.js 에 patch API 작성
  
closed #219