### PR TITLE
[Feat] 가통설계 상세페이지

### DIFF
--- a/backend/src/main/java/com/poscodx/pofect/domain/main/dto/passstandard/ConfirmFactoryStandardResDto.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/main/dto/passstandard/ConfirmFactoryStandardResDto.java
@@ -1,0 +1,63 @@
+package com.poscodx.pofect.domain.main.dto.passstandard;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.poscodx.pofect.domain.passstandard.entity.ConfirmFactoryStandard;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConfirmFactoryStandardResDto {
+
+    @NotBlank
+    private Long id;
+
+//    @NotBlank
+//    @Size(max = 2)
+//    private String gcsCompCode;  // 1.연결결산법인구분
+
+//    @NotBlank
+//    @Size(max = 1)
+//    private String millCd;  // 2.공정계획박판Mill구분
+
+    @NotBlank
+    @Size(max = 2)
+    private String processCd; //3. 박판공정계획공정구분
+
+    @NotBlank
+    @Size(max = 2)
+    private String firmPsFacTp;  // 4.확정통과공장구분
+
+    @Size(max = 680)
+    private String cdExpl;  // 5.코드설명
+
+//    @Size(max = 8)
+//    private String userId;  // 6.박판공정계획사용자ID
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDateTime lastUpdateDate;  // 최종수정일자
+
+    public static ConfirmFactoryStandardResDto toDto(ConfirmFactoryStandard confirmFactoryStandard){
+        return ConfirmFactoryStandardResDto.builder()
+                .id(confirmFactoryStandard.getId())
+                .firmPsFacTp(confirmFactoryStandard.getFirmPsFacTp())
+                .cdExpl(confirmFactoryStandard.getCdExpl())
+                .processCd(confirmFactoryStandard.getProcessCd())
+                .lastUpdateDate(confirmFactoryStandard.getLastUpdateDate())
+                .build();
+    }
+
+//    public static ConfirmFactoryStandardResDto toDto(Object[] confirmFactoryStandard) {
+//    return ConfirmFactoryStandardResDto.builder()
+//            .cdExpl(confirmFactoryStandard[0].toString())
+//            .processCd(confirmFactoryStandard[1].toString())
+//            .firmPsFacTp(confirmFactoryStandard[2].toString())
+//            .build();
+//    }
+}

--- a/backend/src/main/java/com/poscodx/pofect/domain/main/entity/FactoryOrderInfo.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/main/entity/FactoryOrderInfo.java
@@ -204,4 +204,10 @@ public class FactoryOrderInfo extends BaseEntity {
     public void changePosbPassFacCdN(String posbCode) { this.posbPassFacCdN = posbCode; }
 
     public void changeCfirmPassOpCd(String confirmCode) { this.cfirmPassOpCd = confirmCode; }
+
+    public void changePosbPassFacProcess(String process) { this.posbPassFacProcess = process; }
+
+    public void changePosbPassFacEs(String essential) { this.posbPassFacEs = essential; }
+
+    public void changePosbPassFacSize(String size) { this.posbPassFacSize = size; }
 }

--- a/backend/src/main/java/com/poscodx/pofect/domain/main/service/FactoryOrderInfoServiceImpl.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/main/service/FactoryOrderInfoServiceImpl.java
@@ -150,14 +150,17 @@ public class FactoryOrderInfoServiceImpl implements FactoryOrderInfoService{
                 String processCd = list.getProcessCd();
                 String factory = list.getFirmPsFacTp();
 
+                boolean exist = false;
                 for (PossibleToConfirmResDto es : essentialResult) {
                     if(es.getProcessCD().equals(processCd)) {
+                        exist = true;
                         List<String> factories = es.getFirmPsFacTpList();
                         if (factories != null && factories.contains(factory)) {
                             essentialStr.append(1);
                         } else essentialStr.append(0);
                     }
                 }
+                if(!exist) essentialStr.append(0);
             }
             order.changePosbPassFacEs(essentialStr.toString());
 
@@ -170,14 +173,17 @@ public class FactoryOrderInfoServiceImpl implements FactoryOrderInfoService{
                 String processCd = list.getProcessCd();
                 String factory = list.getFirmPsFacTp();
 
+                boolean exist = false;
                 for (SizeStandardSetDto size : sizeResult) {
                     if(size.getProcessCD().equals(processCd)) {
+                        exist = true;
                         List<String> factories = size.getFirmPsFacTpList();
                         if (!factories.isEmpty() && factories.contains(factory)) {
                             sizeStr.append(1);
                         } else sizeStr.append(0);
                     }
                 }
+                if(!exist) sizeStr.append(0);
             }
             order.changePosbPassFacSize(sizeStr.toString());
 

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/controller/ConfirmFactoryStandardController.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/controller/ConfirmFactoryStandardController.java
@@ -3,6 +3,7 @@ package com.poscodx.pofect.domain.passstandard.controller;
 import com.poscodx.pofect.common.dto.ResponseDto;
 import com.poscodx.pofect.domain.passstandard.dto.ConfirmFactoryStandardResDto;
 import com.poscodx.pofect.domain.passstandard.dto.PossibleFactoryStandardResDto;
+import com.poscodx.pofect.domain.passstandard.dto.PossibleToConfirmResDto;
 import com.poscodx.pofect.domain.passstandard.service.ConfirmFactoryStandardService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -38,6 +39,13 @@ public class ConfirmFactoryStandardController {
     @ApiOperation(value = "해당 공정의 공장 리스트 조회", notes = "공정 코드로 해당 공정의 전체 공장 리스트를 조회한다.")
     public ResponseEntity<ResponseDto> getFactoryData(@PathVariable(name = "code") String process){
         List<ConfirmFactoryStandardResDto> result = confirmFactoryStandardService.getFactories(process);
+        return new ResponseEntity<>(new ResponseDto(result), HttpStatus.OK);
+    }
+
+    @GetMapping
+    @ApiOperation(value = "전체 공정의 공장 리스트 조회", notes = "전체 공정마다 각각의 공장 리스트를 조회한다.")
+    public ResponseEntity<ResponseDto> getFactoryList(){
+        List<ConfirmFactoryStandardResDto> result = confirmFactoryStandardService.getFactoryList();
         return new ResponseEntity<>(new ResponseDto(result), HttpStatus.OK);
     }
 

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/repository/ConfirmFactoryStandardRepository.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/repository/ConfirmFactoryStandardRepository.java
@@ -25,6 +25,8 @@ public interface ConfirmFactoryStandardRepository extends JpaRepository<ConfirmF
 
     List<ConfirmFactoryStandard> findAllByProcessCdOrderByProcessCdAsc(String process);
 
+    List<ConfirmFactoryStandard> findAllByOrderByProcessCdAscFirmPsFacTpAsc();
+
     FactoryName findAllByProcessCdAndFirmPsFacTp(String processCd, String firmPsFacTp);
 
     public interface FactoryName {

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/service/ConfirmFactoryStandardService.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/service/ConfirmFactoryStandardService.java
@@ -1,6 +1,7 @@
 package com.poscodx.pofect.domain.passstandard.service;
 
 import com.poscodx.pofect.domain.passstandard.dto.ConfirmFactoryStandardResDto;
+import com.poscodx.pofect.domain.passstandard.dto.PossibleToConfirmResDto;
 
 import java.util.List;
 import java.util.Map;
@@ -12,4 +13,6 @@ public interface ConfirmFactoryStandardService {
     List<ConfirmFactoryStandardResDto> getFactories(String process);
 
     String getFactoryName(String processCd, String firmPsFacTp);
+
+    List<ConfirmFactoryStandardResDto> getFactoryList();
 }

--- a/backend/src/main/java/com/poscodx/pofect/domain/passstandard/service/ConfirmFactoryStandardServiceImpl.java
+++ b/backend/src/main/java/com/poscodx/pofect/domain/passstandard/service/ConfirmFactoryStandardServiceImpl.java
@@ -1,10 +1,13 @@
 package com.poscodx.pofect.domain.passstandard.service;
 
 import com.poscodx.pofect.domain.passstandard.dto.ConfirmFactoryStandardResDto;
+import com.poscodx.pofect.domain.passstandard.dto.PossibleToConfirmResDto;
 import com.poscodx.pofect.domain.passstandard.repository.ConfirmFactoryStandardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,6 +44,33 @@ public class ConfirmFactoryStandardServiceImpl implements ConfirmFactoryStandard
     @Override
     public String getFactoryName(String processCd, String firmPsFacTp) {
         return confirmFactoryStandardRepository.findAllByProcessCdAndFirmPsFacTp(processCd, firmPsFacTp).getCdExpl();
+    }
+
+    @Override
+    public List<ConfirmFactoryStandardResDto> getFactoryList() {
+        return confirmFactoryStandardRepository.findAllByOrderByProcessCdAscFirmPsFacTpAsc().stream()
+                .map(ConfirmFactoryStandardResDto::toDto)
+                .toList();
+
+//        List<PossibleToConfirmResDto> result = new ArrayList<>();
+
+//        // proecssCD, list 형태의 map에 데이터 저장
+//        Map<String, ArrayList<String>> map = new HashMap<>();
+//
+//        for(ConfirmFactoryStandardResDto dto : list) {
+//            ArrayList<String> arr = map.getOrDefault(dto.getProcessCd(), new ArrayList<>());
+//            arr.add(dto.getFirmPsFacTp());
+//
+//            map.put(dto.getProcessCd(), arr);
+//        }
+//
+//        // map -> DTO
+//        for(String key: map.keySet()) {
+//            PossibleToConfirmResDto dto = new PossibleToConfirmResDto(key, map.get(key));
+//            result.add(dto);
+//        }
+//
+//        return result;
     }
 
 }

--- a/frontend/src/pages/main-capacity/capacity-detail.js
+++ b/frontend/src/pages/main-capacity/capacity-detail.js
@@ -230,27 +230,82 @@ const CapacityDetail = (props) => {
                     <TableCell
                       colSpan={2}
                       align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacProcess != null &&
+                        props.order.posbPassFacProcess.substr(0, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
-                    <TableCell colSpan={2} align="center"></TableCell>
                     <TableCell
                       colSpan={2}
                       align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacProcess != null &&
+                        props.order.posbPassFacProcess.substr(1, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
-                    <TableCell colSpan={3} align="center"></TableCell>
+                    <TableCell
+                      colSpan={2}
+                      align="center"
+                      style={
+                        props.order.posbPassFacProcess != null &&
+                        props.order.posbPassFacProcess.substr(2, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
                     <TableCell
                       colSpan={3}
                       align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacProcess != null &&
+                        props.order.posbPassFacProcess.substr(3, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
-                    <TableCell colSpan={2} align="center"></TableCell>
+                    <TableCell
+                      colSpan={3}
+                      align="center"
+                      style={
+                        props.order.posbPassFacProcess != null &&
+                        props.order.posbPassFacProcess.substr(4, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
                     <TableCell
                       colSpan={2}
                       align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacProcess != null &&
+                        props.order.posbPassFacProcess.substr(5, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
-                    <TableCell align="center"></TableCell>
+                    <TableCell
+                      colSpan={2}
+                      align="center"
+                      style={
+                        props.order.posbPassFacProcess != null &&
+                        props.order.posbPassFacProcess.substr(6, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacProcess != null &&
+                        props.order.posbPassFacProcess.substr(7, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell style={{ fontWeight: "bold", fontSize: 17 }}>
@@ -258,33 +313,157 @@ const CapacityDetail = (props) => {
                     </TableCell>
                     <TableCell
                       align="center"
-                      style={{ background: "lightgrey" }}
-                    ></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell
-                      align="center"
-                      style={{ background: "lightgrey" }}
-                    ></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell
-                      align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(0, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
                     <TableCell
                       align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(1, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(2, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(3, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(4, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(5, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(6, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(7, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(8, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(9, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(10, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(11, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(12, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(13, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(14, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(15, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacEs != null &&
+                        props.order.posbPassFacEs.substr(16, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell style={{ fontWeight: "bold", fontSize: 17 }}>
@@ -292,36 +471,157 @@ const CapacityDetail = (props) => {
                     </TableCell>
                     <TableCell
                       align="center"
-                      style={{ background: "lightgrey" }}
-                    ></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell
-                      align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(0, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
                     <TableCell
                       align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(1, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
                     <TableCell
                       align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(2, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
-                    <TableCell align="center"></TableCell>
                     <TableCell
                       align="center"
-                      style={{ background: "lightgrey" }}
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(3, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
                     ></TableCell>
-                    <TableCell align="center"></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(4, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(5, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(6, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(7, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(8, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(9, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(10, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(11, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(12, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(13, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(14, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(15, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
+                    <TableCell
+                      align="center"
+                      style={
+                        props.order.posbPassFacSize != null &&
+                        props.order.posbPassFacSize.substr(16, 1) == "1"
+                          ? { background: "lightgrey" }
+                          : null
+                      }
+                    ></TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell style={{ fontWeight: "bold", fontSize: 17 }}>


### PR DESCRIPTION
### 목적

- 가통설계 상세페이지 표 구현
  
### 주요 변경사항
  
- [x] 가통설계 시 각각 설계 결과 DB에 저장
- [x] front에서 표에 설계 결과 반영되도록 데이터 연결
  
### 이슈 (없으면 삭제)
  
- Closed #201 
- Closed #205 
