### PR TITLE
[Feat] 메인, 로그 QA

### DIFF
--- a/frontend/src/pages/capacity/index.js
+++ b/frontend/src/pages/capacity/index.js
@@ -35,6 +35,7 @@ import {
 import { Report } from "src/notifix/notiflix-report-aio";
 
 import React, { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 import CapacityStandardApi from "src/pages/api/pofect/CapacityApi";
 import MyD3Heatmap from "../../views/capacity/d3-heat";
 
@@ -42,13 +43,13 @@ import * as FileSaver from "file-saver";
 import XLSX from "sheetjs-style";
 
 ChartJS.register(
-    CategoryScale,
-    LinearScale,
-    BarElement,
-    Title,
-    Tooltip,
-    Legend,
-    ArcElement
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  ArcElement
 );
 
 function MyCell(props) {
@@ -80,6 +81,8 @@ function MyCell(props) {
 }
 
 const CapacityMgt = () => {
+  const router = useRouter();
+
   // 능력
   const [capacity, setCapacity] = useState([]);
   const [labels, setLabels] = useState([]);
@@ -96,12 +99,11 @@ const CapacityMgt = () => {
   // 로딩
   const [loading, setLoading] = useState(true);
 
-
   //Update
   const handleCellEditCommit = (params) => {
     console.log(params);
     const updatedList = capacity.map((item) =>
-        item.id === params.id ? params : item
+      item.id === params.id ? params : item
     );
 
     setCapacity(updatedList);
@@ -118,7 +120,11 @@ const CapacityMgt = () => {
 
     CapacityStandardApi.getWeek("H", ["D", "E"], (data) => {
       const list = data.response;
-      const select = list[0];
+
+      const select = null;
+      if (router.query.week === undefined) select = list[0];
+      else select = router.query.week;
+
       console.log("select ", select);
       setWeekList((prev) => {
         return { ...prev, list, select };
@@ -127,10 +133,8 @@ const CapacityMgt = () => {
       CapacityStandardApi.getCapacityListByWeek(select, (data) => {
         setCapacity(data.response);
         setLoading(false);
-
       });
     });
-
   }, []);
 
   const handleCloseAlert = () => {
@@ -143,18 +147,18 @@ const CapacityMgt = () => {
     };
 
     CapacityStandardApi.createCapacity(capacityData)
-        .then((response) => {
-          CapacityStandardApi.getCapacityListByWeek(
-              weekList.select,
-              (newData) => {
-                setCapacity(newData.response);
-              }
-          );
-          handleCloseAlert();
-        })
-        .catch((error) => {
-          console.error("Failed to create capacity data:", error);
-        });
+      .then((response) => {
+        CapacityStandardApi.getCapacityListByWeek(
+          weekList.select,
+          (newData) => {
+            setCapacity(newData.response);
+          }
+        );
+        handleCloseAlert();
+      })
+      .catch((error) => {
+        console.error("Failed to create capacity data:", error);
+      });
   };
 
   const handleSearch = async () => {
@@ -206,8 +210,8 @@ const CapacityMgt = () => {
       editable: true,
       headerAlign: "center",
       sortable: false,
-        type: "number",
-        valueFormatter: (params) => Math.max(0, params.value)
+      type: "number",
+      valueFormatter: (params) => Math.max(0, params.value),
     },
     {
       field: "progressQty",
@@ -234,342 +238,351 @@ const CapacityMgt = () => {
       if (isNaN(item.faAdjustmentWgt)) {
         Notify.failure("공정 조정량은 숫자만 가능합니다.");
         updateFlag = true;
-      } else if (item.faAdjustmentWgt === undefined || item.faAdjustmentWgt === null || item.faAdjustmentWgt === "") {
-
+      } else if (
+        item.faAdjustmentWgt === undefined ||
+        item.faAdjustmentWgt === null ||
+        item.faAdjustmentWgt === ""
+      ) {
         Notify.failure("공정 조정량이 비어있습니다.");
         updateFlag = true;
-
       }
     });
 
     if (updateFlag) {
       // alert(result);
-
     } else if (!updateFlag) {
-
       Report.warning(
-          "",
-          "조정량 수정 값을 저장하시겠습니까?",
-          "확인",
-          () => {
-            CapacityStandardApi.updateSave(capacity, (data) => {
-                  Notify.success("저장되었습니다.");
-                  capacityApi();     });
-
-          },
-          "취소",
-          {
-            backOverlayClickToClose: true,
-          }
+        "",
+        "조정량 수정 값을 저장하시겠습니까?",
+        "확인",
+        () => {
+          CapacityStandardApi.updateSave(capacity, (data) => {
+            Notify.success("저장되었습니다.");
+            capacityApi();
+          });
+        },
+        "취소",
+        {
+          backOverlayClickToClose: true,
+        }
       );
-
-
-
-
     }
   };
 
-
   //excel
-    // 한글 헤더
-    const koreanHeaderMap = {
-        "id": "code",
-        "processName": "공정",
-        "firmPsFacTp": "공장",
-        "planQty": "능력량",
-        "faAdjustmentWgt": "조정량",
-        "progressQty": "투입량",
-        "remainQty": "잔여량",
-        // "rowSpan": ""
-
-    };
+  // 한글 헤더
+  const koreanHeaderMap = {
+    id: "code",
+    processName: "공정",
+    firmPsFacTp: "공장",
+    planQty: "능력량",
+    faAdjustmentWgt: "조정량",
+    progressQty: "투입량",
+    remainQty: "잔여량",
+    // "rowSpan": ""
+  };
 
   const fileType =
-      "application/vnd.openxmlformats-officedcoument.spreadsheetml.sheet;charset=UTF-8";
+    "application/vnd.openxmlformats-officedcoument.spreadsheetml.sheet;charset=UTF-8";
   const fileExtension = ".xlsx";
 
   const exportToExcel = async () => {
-      // 헤더 순서
-      const originalHeader = ["id", "processName", "firmPsFacTp", "planQty", "faAdjustmentWgt", "progressQty", "remainQty"];
+    // 헤더 순서
+    const originalHeader = [
+      "id",
+      "processName",
+      "firmPsFacTp",
+      "planQty",
+      "faAdjustmentWgt",
+      "progressQty",
+      "remainQty",
+    ];
 
-      // possibleList의 id를 기준으로 정렬
-      const sortedCapacityList = [...capacity].sort((a, b) => a.id - b.id);
+    // possibleList의 id를 기준으로 정렬
+    const sortedCapacityList = [...capacity].sort((a, b) => a.id - b.id);
 
-      // 데이터를 헤더와 일치하는 형식으로 변환
-      const excelData = sortedCapacityList.map(item => originalHeader.map(key => item[key]));
+    // 데이터를 헤더와 일치하는 형식으로 변환
+    const excelData = sortedCapacityList.map((item) =>
+      originalHeader.map((key) => item[key])
+    );
 
-      // 헤더를 한글로 변경
-      const koreanHeader = originalHeader.map(englishKey => koreanHeaderMap[englishKey] || englishKey);
+    // 헤더를 한글로 변경
+    const koreanHeader = originalHeader.map(
+      (englishKey) => koreanHeaderMap[englishKey] || englishKey
+    );
 
-      // 헤더와 데이터를 함께 전달하여 엑셀 생성
-      const ws = XLSX.utils.aoa_to_sheet([koreanHeader, ...excelData]);
-      const wb = { Sheets: { data: ws }, SheetNames: ["data"] };
+    // 헤더와 데이터를 함께 전달하여 엑셀 생성
+    const ws = XLSX.utils.aoa_to_sheet([koreanHeader, ...excelData]);
+    const wb = { Sheets: { data: ws }, SheetNames: ["data"] };
     const excelBuffer = XLSX.write(wb, { bookType: "xlsx", type: "array" });
     const data = new Blob([excelBuffer], { type: fileType });
     FileSaver.saveAs(data, "투입 능력 산정" + fileExtension);
   };
 
   return (
-      <>
-        <Grid item xs={12} sx={{ paddingBottom: 4 }}>
-          <Card></Card>
-          <Typography variant="h4">투입 능력 관리</Typography>
-        </Grid>
-        <div
+    <>
+      <Grid item xs={12} sx={{ paddingBottom: 4 }}>
+        <Card></Card>
+        <Typography variant="h4">투입 능력 관리</Typography>
+      </Grid>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <FormControl
+            sx={{ m: 1 }}
             style={{
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "space-between",
-              alignItems: "center",
+              paddingTop: 10,
+              paddingBottom: 20,
+              marginRight: 10,
             }}
+          >
+            <InputLabel id="label1" style={{ paddingTop: 10 }}>
+              구분
+            </InputLabel>
+            <Select
+              labelId="분류"
+              id="demo-multiple-name"
+              defaultValue="T"
+              input={<OutlinedInput label="구분" />}
+              onChange={(e) => {
+                console.log(e);
+              }}
+              style={{ height: 40 }}
+            >
+              <MenuItem value="T">포항</MenuItem>
+            </Select>
+          </FormControl>
+          <FormControl
+            sx={{ m: 1 }}
+            style={{
+              paddingTop: 10,
+              paddingBottom: 20,
+              marginRight: 10,
+            }}
+          >
+            <InputLabel id="label3" style={{ paddingTop: 10 }}>
+              출강주
+            </InputLabel>
+            <Select
+              labelId="출강주"
+              id="demo-multiple-name"
+              value={weekList.select}
+              defaultValue={0}
+              input={<OutlinedInput label="출강주" />}
+              onChange={(e) => {
+                setWeekList(
+                  Object.assign({}, weekList, {
+                    select: e.target.value,
+                  })
+                );
+              }}
+              style={{ height: 40 }}
+            >
+              {weekList.list.map((code, idx) => {
+                return (
+                  <MenuItem key={idx} value={code}>
+                    {code}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+        </div>
+        <div>
+          {!loading && capacity.length === 0 ? (
+            <Button
+              size="small"
+              type="submit"
+              variant="contained"
+              onClick={handleInsert}
+              style={{ backgroundColor: "darkred" }}
+            >
+              추가
+            </Button>
+          ) : (
+            <></>
+          )}
+          <Button
+            size="small"
+            type="submit"
+            variant="contained"
+            onClick={handleSearch}
+            style={{ backgroundColor: "#E29E21" }}
+          >
+            조회
+          </Button>
+          <Button
+            size="small"
+            type="submit"
+            variant="contained"
+            onClick={updateCapacity}
+            style={{ backgroundColor: "#0A5380" }}
+          >
+            저장
+          </Button>
+          <Button
+            size="small"
+            type="submit"
+            variant="contained"
+            onClick={exportToExcel}
+            style={{ backgroundColor: "darkgreen" }}
+          >
+            Excel
+          </Button>
+        </div>
+      </div>
+      <div style={{ display: "flex" }}>
+        <Card
+          elevation={3}
+          style={{
+            flexBasis: "50%",
+            marginRight: "16px",
+            padding: "16px",
+          }}
         >
-          <div>
-            <FormControl
-                sx={{ m: 1 }}
-                style={{
-                  paddingTop: 10,
-                  paddingBottom: 20,
-                  marginRight: 10,
-                }}
-            >
-              <InputLabel id="label1" style={{ paddingTop: 10 }}>
-                구분
-              </InputLabel>
-              <Select
-                  labelId="분류"
-                  id="demo-multiple-name"
-                  defaultValue="T"
-                  input={<OutlinedInput label="구분" />}
-                  onChange={(e) => {
-                    console.log(e);
-                  }}
-                  style={{ height: 40 }}
-              >
-                <MenuItem value="T">포항</MenuItem>
-              </Select>
-            </FormControl>
-            <FormControl
-                sx={{ m: 1 }}
-                style={{
-                  paddingTop: 10,
-                  paddingBottom: 20,
-                  marginRight: 10,
-                }}
-            >
-              <InputLabel id="label3" style={{ paddingTop: 10 }}>
-                출강주
-              </InputLabel>
-              <Select
-                  labelId="출강주"
-                  id="demo-multiple-name"
-                  value={weekList.select}
-                  defaultValue={0}
-                  input={<OutlinedInput label="출강주" />}
-                  onChange={(e) => {
-                    setWeekList(
-                        Object.assign({}, weekList, {
-                          select: e.target.value,
-                        })
-                    );
-                  }}
-                  style={{ height: 40 }}
-              >
-                {weekList.list.map((code, idx) => {
-                  return (
-                      <MenuItem key={idx} value={code}>
-                        {code}
-                      </MenuItem>
-                  );
-                })}
-              </Select>
-            </FormControl>
-          </div>
-          <div>
-            {!loading &&capacity.length === 0 ?(
-                <Button
-                    size="small"
-                    type="submit"
-                    variant="contained"
-                    onClick={handleInsert}
-                    style={{backgroundColor: "darkred"}}
-                >
-                  추가
-                </Button>):(<></>)}
-            <Button
-                size="small"
-                type="submit"
-                variant="contained"
-                onClick={handleSearch}
-                style={{ backgroundColor: "#E29E21" }}
-            >
-              조회
-            </Button>
-            <Button
-                size="small"
-                type="submit"
-                variant="contained"
-                onClick={updateCapacity}
-                style={{ backgroundColor: "#0A5380" }}
-            >
-              저장
-            </Button>
-            <Button
-                size="small"
-                type="submit"
-                variant="contained"
-                onClick={exportToExcel}
-                style={{ backgroundColor: "darkgreen" }}
-            >
-              Excel
-            </Button>
-          </div>
-        </div>
-        <div style={{ display: "flex" }}>
-          <Card
-              elevation={3}
-              style={{
-                flexBasis: "50%",
-                marginRight: "16px",
-                padding: "16px",
-              }}
+          <Grid
+            item
+            xs={4}
+            sx={{ paddingBottom: 5, paddingTop: 3, paddingLeft: 3 }}
           >
-            <Grid
-                item
-                xs={4}
-                sx={{ paddingBottom: 5, paddingTop: 3, paddingLeft: 3 }}
-            >
-              <Typography variant="h5"> 공정별 능력 관리 </Typography>
-            </Grid>
+            <Typography variant="h5"> 공정별 능력 관리 </Typography>
+          </Grid>
 
-            <Box
-                sx={{
-                  height: "100",
-                  width: "94.5%",
-                  marginBottom: "20px",
-                  marginLeft: "15px",
-                  "& .custom-data-grid .MuiDataGrid-columnsContainer, & .custom-data-grid .MuiDataGrid-cell":
-                      {
-                        borderBottom: "1px solid rgba(225, 234, 239, 1)",
-                        borderRight: "1px solid rgba(225, 234, 239, 1)",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                      },
-                  "& .custom-data-grid .MuiDataGrid-columnHeader": {
-                    cursor: "pointer",
-                    borderBottom: "1px solid rgba(225, 234, 239, 1)",
-                    borderRight: "1px solid rgba(225, 234, 239, 1)",
-                  },
-                  "& .custom-data-grid .MuiDataGrid-columnHeader--filledGroup  .MuiDataGrid-columnHeaderTitleContainer":
-                      {
-                        borderBottomStyle: "none",
-                      },
-
-                  "& .custom-data-grid .MuiDataGrid-columnHeadersInner": {
-                    backgroundColor: "#F5F9FF",
-                  },
-                  "& .custom-data-grid .MuiDataGrid-sortIcon": {
-                    display: "none",
-                  },
-                }}
-            >
-              {capacity.length === 0 ? (
-                  <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        height: "100%",
-                        backgroundColor: "rgba(255, 255, 255, 0.7)",
-                      }}
-                  >
-                    <Typography variant="h6">데이터가 없습니다.</Typography>
-                  </div>
-              ) : (
-                  <DataGrid
-                      className="custom-data-grid"
-                      disableRowSelectionOnClick
-                      rows={capacity}
-                      columns={columns}
-                      processRowUpdate={(newVal) => {
-                        handleCellEditCommit(newVal);
-                        return newVal;
-                      }}
-                      components={{
-                        Cell: MyCell,
-                      }}
-                      rowHeight={40}
-                      hideFooterPagination={true}
-                      hideFooter={true}
-                      disableColumnReorder
-                  />
-              )}
-            </Box>
-          </Card>
-          <Card
-              elevation={3}
-              style={{
-                flexBasis: "50%",
-                padding: "16px",
-              }}
-          >
-            <Grid
-                item
-                xs={4}
-                sx={{ paddingBottom: 10, paddingTop: 3, paddingLeft: 3 }}
-            >
-              <Typography variant="h5"> 공장 부하 예상 현황 </Typography>
-              {loading && <div>Loading...</div>}
-
-              {!loading &&capacity.length === 0 ? (
-                  <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        height: "100%",
-                        backgroundColor: "rgba(255, 255, 255, 0.7)",
-                        marginTop: "20px",
-                      }}
-                  >
-                    <Typography variant="h6">데이터가 없습니다.</Typography>
-                  </div>
-              ) : (
-                  <MyD3Heatmap capacity={capacity} />
-              )}
-            </Grid>
-          </Card>
-        </div>
-
-        {/* alert */}
-        {showAlert &&
-            Report.warning(
-                " ",
-                "<div style='text-align: center;'>" +
-                "현재 [" +
-                weekList.select +
-                "] 출강 주의 " +
-                "<br />" +
-                "투입 능력 관리 데이터가 없습니다." +
-                "<br />" +
-                "<br />" +
-                "데이터를 추가 하시겠습니까?" +
-                "</div>",
-                "확인",
-                () => {
-                  handleAccept();
-                },
-                "취소",
-                () => {
-                  handleCloseAlert();
-                },
+          <Box
+            sx={{
+              height: "100",
+              width: "94.5%",
+              marginBottom: "20px",
+              marginLeft: "15px",
+              "& .custom-data-grid .MuiDataGrid-columnsContainer, & .custom-data-grid .MuiDataGrid-cell":
                 {
-                  backOverlayClickToClose: true,
-                  cssAnimationStyle: "zoom",
-                  cssAnimationDuration: 400,
-                }
+                  borderBottom: "1px solid rgba(225, 234, 239, 1)",
+                  borderRight: "1px solid rgba(225, 234, 239, 1)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                },
+              "& .custom-data-grid .MuiDataGrid-columnHeader": {
+                cursor: "pointer",
+                borderBottom: "1px solid rgba(225, 234, 239, 1)",
+                borderRight: "1px solid rgba(225, 234, 239, 1)",
+              },
+              "& .custom-data-grid .MuiDataGrid-columnHeader--filledGroup  .MuiDataGrid-columnHeaderTitleContainer":
+                {
+                  borderBottomStyle: "none",
+                },
+
+              "& .custom-data-grid .MuiDataGrid-columnHeadersInner": {
+                backgroundColor: "#F5F9FF",
+              },
+              "& .custom-data-grid .MuiDataGrid-sortIcon": {
+                display: "none",
+              },
+            }}
+          >
+            {capacity.length === 0 ? (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: "100%",
+                  backgroundColor: "rgba(255, 255, 255, 0.7)",
+                }}
+              >
+                <Typography variant="h6">데이터가 없습니다.</Typography>
+              </div>
+            ) : (
+              <DataGrid
+                className="custom-data-grid"
+                disableRowSelectionOnClick
+                rows={capacity}
+                columns={columns}
+                processRowUpdate={(newVal) => {
+                  handleCellEditCommit(newVal);
+                  return newVal;
+                }}
+                components={{
+                  Cell: MyCell,
+                }}
+                rowHeight={40}
+                hideFooterPagination={true}
+                hideFooter={true}
+                disableColumnReorder
+              />
             )}
-      </>
+          </Box>
+        </Card>
+        <Card
+          elevation={3}
+          style={{
+            flexBasis: "50%",
+            padding: "16px",
+          }}
+        >
+          <Grid
+            item
+            xs={4}
+            sx={{ paddingBottom: 10, paddingTop: 3, paddingLeft: 3 }}
+          >
+            <Typography variant="h5"> 공장 부하 예상 현황 </Typography>
+            {loading && <div>Loading...</div>}
+
+            {!loading && capacity.length === 0 ? (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: "100%",
+                  backgroundColor: "rgba(255, 255, 255, 0.7)",
+                  marginTop: "20px",
+                }}
+              >
+                <Typography variant="h6">데이터가 없습니다.</Typography>
+              </div>
+            ) : (
+              <MyD3Heatmap capacity={capacity} />
+            )}
+          </Grid>
+        </Card>
+      </div>
+
+      {/* alert */}
+      {showAlert &&
+        Report.warning(
+          " ",
+          "<div style='text-align: center;'>" +
+            "현재 [" +
+            weekList.select +
+            "] 출강 주의 " +
+            "<br />" +
+            "투입 능력 관리 데이터가 없습니다." +
+            "<br />" +
+            "<br />" +
+            "데이터를 추가 하시겠습니까?" +
+            "</div>",
+          "확인",
+          () => {
+            handleAccept();
+          },
+          "취소",
+          () => {
+            handleCloseAlert();
+          },
+          {
+            backOverlayClickToClose: true,
+            cssAnimationStyle: "zoom",
+            cssAnimationDuration: 400,
+          }
+        )}
+    </>
   );
 };
 

--- a/frontend/src/pages/log/index.js
+++ b/frontend/src/pages/log/index.js
@@ -352,6 +352,7 @@ const Log = () => {
           style={{
             flexBasis: "50%",
             padding: "16px",
+            height: "750px",
           }}
         >
           <Grid

--- a/frontend/src/pages/main-capacity/index.js
+++ b/frontend/src/pages/main-capacity/index.js
@@ -16,10 +16,10 @@ import MainApi from "src/pages/api/pofect/MainApi";
 import Card from "@mui/material/Card";
 import { Notify } from "src/notifix/notiflix-notify-aio";
 
-import CapacityDetail from "../../views/main-capacity/capacity-detail";
-
 import * as FileSaver from "file-saver";
 import XLSX from "sheetjs-style";
+
+import CapacityDetail from "../../views/main-capacity/capacity-detail";
 import CapacityModal from "src/views/main-capacity/capacity-modal";
 import withAuth from "../api/auth/withAuth";
 
@@ -193,10 +193,132 @@ const MainCapacity = ({ userData }) => {
   };
 
   const exportToExcel = async () => {
+    const koreanHeaderMap = {
+      gcsCompCode: "법인",
+      millCd: "소구분",
+      orderHeadLineNo: "주문번호",
+      creationDate: "생성일자",
+      osMainStatusCd: "진도",
+      faConfirmFlag: "공장결정확정구분",
+      posbPassFacCdN: "가능통과공정코드",
+      posbPassFacUpdateDate: "가능통과공정설계일자",
+      cfirmPassOpCd: "확정통과공정코드",
+      ordPdtItpCdN: "품종",
+      ordPdtItdsCdN: "품명",
+      adjustConsBktStartDttm: "ATP조정일",
+      customerNumber: "고객사코드",
+      customerName: "고객사명",
+      ordThwTapWekCd: "출강주",
+      orderType: "수주구분",
+      orderLineQty: "주문량",
+      orderThick: "두께",
+      orderWidth: "폭",
+      orderLength: "길이",
+      orderUsageCdN: "용도",
+      orderEdgeCode: "Edge",
+      stockCode: "제품재고판매",
+      salesPerson: "영업담당자",
+      salesCodeN: "판매특기",
+      salCusManDblTp: "판매고객사 대표산업",
+      salCusLocLClsTp: "판매고객사 지역대분류",
+      prodStdPackTolMin: "제품정포장하한중량",
+      prodStdPackTolMax: "제품정포장상한중량",
+      specificationCdN: "제품규격약호",
+      surfaceFinishCd: "표면지정코드",
+      postTreatmentMethodCdN: "후처리코드",
+      oilingMethodCd: "도유코드",
+      planningItemCodeN: "PlanningItem코드",
+      smSteelGrdN: "출강목표번호",
+      moltenSteelCharCdN: "용강특성",
+      tsAim: "목표TS",
+      unitWeight: "제품칫수계산단중",
+      hrSpComposite: "열연SkinPass합성지정",
+      surfaceGrd: "표면등급",
+      shapeGrd: "형상등급",
+      poscoProdGrdN: "제품사내보증번호",
+      hrProdThkAim: "열연목표두께",
+      hrProdWthAim: "열연목표폭",
+      hrRollUnitWgtMax: "압연상한중량",
+      sm2ndRfnCd: "제강2차정련코드",
+      skinpassFlag: "제품SkinPass지정여부",
+      packingType: "포장방법",
+      facAllocWgt: "소내공장결정중량",
+      faAllocDate: "생산가능공장결정일자",
+      errorMessage: "ErrorMessage",
+      msgcode: "박판공정계획Message코드",
+      lastUpdateDate: "최종수정일자",
+    };
+
+    const originalHeader = [
+      "gcsCompCode",
+      "millCd",
+      "orderHeadLineNo",
+      "creationDate",
+      "osMainStatusCd",
+      "faConfirmFlag",
+      "posbPassFacCdN",
+      "posbPassFacUpdateDate",
+      "cfirmPassOpCd",
+      "ordPdtItpCdN",
+      "ordPdtItdsCdN",
+      "adjustConsBktStartDttm",
+      "customerNumber",
+      "customerName",
+      "ordThwTapWekCd",
+      "orderType",
+      "orderLineQty",
+      "orderThick",
+      "orderWidth",
+      "orderLength",
+      "orderUsageCdN",
+      "orderEdgeCode",
+      "stockCode",
+      "salesPerson",
+      "salesCodeN",
+      "salCusManDblTp",
+      "salCusLocLClsTp",
+      "prodStdPackTolMin",
+      "prodStdPackTolMax",
+      "specificationCdN",
+      "surfaceFinishCd",
+      "postTreatmentMethodCdN",
+      "oilingMethodCd",
+      "planningItemCodeN",
+      "smSteelGrdN",
+      "moltenSteelCharCdN",
+      "tsAim",
+      "unitWeight",
+      "hrSpComposite",
+      "surfaceGrd",
+      "shapeGrd",
+      "poscoProdGrdN",
+      "hrProdThkAim",
+      "hrProdWthAim",
+      "hrRollUnitWgtMax",
+      "sm2ndRfnCd",
+      "skinpassFlag",
+      "packingType",
+      "facAllocWgt",
+      "faAllocDate",
+      "errorMessage",
+      "msgcode",
+      "lastUpdateDate",
+    ];
+
+    const sortedOrderList = [...orderList.list].sort((a, b) => a.id - b.id);
+    const excelData = sortedOrderList.map((item) =>
+      originalHeader.map((key) => item[key])
+    );
+    const koreanHeader = originalHeader.map(
+      (englishKey) => koreanHeaderMap[englishKey] || englishKey
+    );
+
     const fileType =
       "application/vnd.openxmlformats-officedcoument.spreadsheetml.sheet;charset=UTF-8";
     const fileExtension = ".xlsx";
-    const ws = XLSX.utils.json_to_sheet(orderList.list);
+
+    const ws = XLSX.utils.aoa_to_sheet([koreanHeader, ...excelData]);
+    // const ws = XLSX.utils.json_to_sheet(orderList.list);
     const wb = { Sheets: { data: ws }, SheetNames: ["data"] };
     const excelBuffer = XLSX.write(wb, { bookType: "xlsx", type: "array" });
     const data = new Blob([excelBuffer], { type: fileType });
@@ -209,7 +331,6 @@ const MainCapacity = ({ userData }) => {
       field: "gcsCompCode",
       headerName: "법인",
       width: 100,
-
       editable: false,
       headerAlign: "center",
     },
@@ -217,7 +338,6 @@ const MainCapacity = ({ userData }) => {
       field: "millCd",
       headerName: "소구분",
       width: 100,
-
       editable: false,
       headerAlign: "center",
     },
@@ -239,7 +359,6 @@ const MainCapacity = ({ userData }) => {
       field: "osMainStatusCd",
       headerName: "진도",
       width: 100,
-
       editable: false,
       headerAlign: "center",
     },
@@ -252,7 +371,7 @@ const MainCapacity = ({ userData }) => {
       renderCell: (params) => {
         const flag = params.value;
 
-        if (flag === "A") {
+        if (flag === "D") {
           return (
             <Chip
               variant="outlined"
@@ -262,7 +381,7 @@ const MainCapacity = ({ userData }) => {
             />
           );
         }
-        if (flag === "B") {
+        if (flag === "E") {
           return (
             <Chip
               variant="outlined"
@@ -272,17 +391,6 @@ const MainCapacity = ({ userData }) => {
             />
           );
         }
-        if (flag === "C") {
-          return (
-            <Chip
-              variant="outlined"
-              color="error"
-              size="small"
-              label={params.value}
-            />
-          );
-        }
-        // <Chip icon={isRejected ? <WarningIcon/> : <CheckIcon/>}  label={params.value} variant={"outlined"} color={isRejected ? "error" : "success"} />;
       },
     },
     {

--- a/frontend/src/pages/main-capacity/index.js
+++ b/frontend/src/pages/main-capacity/index.js
@@ -756,7 +756,7 @@ const MainCapacity = ({ userData }) => {
                   setFlag(["A", "B", "C"]);
                 }}
               >
-                ALL
+                All
               </MenuItem>
               <MenuItem
                 value={1}

--- a/frontend/src/pages/main-capacity/index.js
+++ b/frontend/src/pages/main-capacity/index.js
@@ -168,7 +168,10 @@ const MainCapacity = ({ userData }) => {
     });
 
     // 설계 modal, progress bar start
-    const time = allCnt * 0.2;
+    const time = 0;
+    if (allCnt < 5) time = 1;
+    else allCnt * 0.2;
+
     setModal((prev) => {
       return { ...prev, open: true, time };
     });
@@ -179,13 +182,17 @@ const MainCapacity = ({ userData }) => {
         return { ...prev, open: false };
       });
 
-      Notify.success(res.success + "/" + allCnt + "건 성공", {
-        showOnlyTheLastOne: false,
-      });
-      Notify.failure(res.fail + "/" + allCnt + "건 실패", {
-        showOnlyTheLastOne: false,
-      });
-      setRowSelectionModel([]);
+      if (res.success > 0) {
+        Notify.success(res.success + "건 성공", {
+          showOnlyTheLastOne: false,
+        });
+      }
+      if (res.fail > 0) {
+        Notify.failure(res.fail + "건 실패", {
+          showOnlyTheLastOne: false,
+        });
+      }
+      // setRowSelectionModel([]);
 
       /** 리스트 update */
       getOrders(codeNameList.select, weekList.select);
@@ -371,7 +378,7 @@ const MainCapacity = ({ userData }) => {
       renderCell: (params) => {
         const flag = params.value;
 
-        if (flag === "D") {
+        if (flag === "A") {
           return (
             <Chip
               variant="outlined"
@@ -381,11 +388,21 @@ const MainCapacity = ({ userData }) => {
             />
           );
         }
-        if (flag === "E") {
+        if (flag === "B") {
           return (
             <Chip
               variant="outlined"
               color="success"
+              size="small"
+              label={params.value}
+            />
+          );
+        }
+        if (flag === "C") {
+          return (
+            <Chip
+              variant="outlined"
+              color="error"
               size="small"
               label={params.value}
             />

--- a/frontend/src/pages/main-capacity/index.js
+++ b/frontend/src/pages/main-capacity/index.js
@@ -192,13 +192,11 @@ const MainCapacity = ({ userData }) => {
           showOnlyTheLastOne: false,
         });
       }
-      // setRowSelectionModel([]);
 
       /** 리스트 update */
       getOrders(codeNameList.select, weekList.select);
 
       //** 체크된 주문 리스트에서 설계 오류인 주문 제외하기  */
-
       // 선택된 행 중에서 공장결정확정구분이 'C'인 행을 제외한 행들
       const rowsToRemove = orderList.list
         .filter(
@@ -825,7 +823,6 @@ const MainCapacity = ({ userData }) => {
                     select: e.target.value,
                   })
                 );
-                // setSelectCodeName(e.target.value);
               }}
               style={{ height: 40 }}
             >

--- a/frontend/src/pages/main-capacity/index.js
+++ b/frontend/src/pages/main-capacity/index.js
@@ -196,6 +196,24 @@ const MainCapacity = ({ userData }) => {
 
       /** 리스트 update */
       getOrders(codeNameList.select, weekList.select);
+
+      //** 체크된 주문 리스트에서 설계 오류인 주문 제외하기  */
+
+      // 선택된 행 중에서 공장결정확정구분이 'C'인 행을 제외한 행들
+      const rowsToRemove = orderList.list
+        .filter(
+          (row) =>
+            rowSelectionModel.includes(row.id) && row.faConfirmFlag === "C"
+        )
+        .map((row) => row.id);
+
+      // 선택된 행 중에서 "flag" 컬럼이 "C"가 아닌 행들의 ID
+      const filteredRowIds = rowSelectionModel.filter(
+        (id) => !rowsToRemove.includes(id)
+      );
+
+      // 필터링된 행으로 rowSelectionModel 업데이트
+      setRowSelectionModel(filteredRowIds);
     }, time * 1000);
   };
 

--- a/frontend/src/pages/main-confirm/index.js
+++ b/frontend/src/pages/main-confirm/index.js
@@ -184,7 +184,10 @@ const MainConfirm = ({ userData }) => {
           " 출강주의 투입 능력 데이터가 없습니다.<br />데이터를 추가해주세요.",
         "확인",
         () => {
-          router.push("/capacity");
+          router.push({
+            pathname: "/capacity",
+            query: { week: weekResult[0] },
+          });
         },
         "취소",
         // () => {},

--- a/frontend/src/pages/main-confirm/index.js
+++ b/frontend/src/pages/main-confirm/index.js
@@ -14,13 +14,14 @@ import {
   Box,
   Chip,
 } from "@mui/material";
-import MainApi from "src/pages/api/pofect/MainApi";
-import OrderDetail from "../../views/main-confirm/order-detail";
 import { Report } from "src/notifix/notiflix-report-aio";
 import { Notify } from "src/notifix/notiflix-notify-aio";
 
 import * as FileSaver from "file-saver";
 import XLSX from "sheetjs-style";
+
+import MainApi from "src/pages/api/pofect/MainApi";
+import OrderDetail from "../../views/main-confirm/order-detail";
 import withAuth from "../api/auth/withAuth";
 
 function MyCell(props) {
@@ -222,10 +223,132 @@ const MainConfirm = ({ userData }) => {
   };
 
   const exportToExcel = async () => {
+    const koreanHeaderMap = {
+      gcsCompCode: "법인",
+      millCd: "소구분",
+      orderHeadLineNo: "주문번호",
+      creationDate: "생성일자",
+      osMainStatusCd: "진도",
+      faConfirmFlag: "공장결정확정구분",
+      posbPassFacCdN: "가능통과공정코드",
+      posbPassFacUpdateDate: "가능통과공정설계일자",
+      cfirmPassOpCd: "확정통과공정코드",
+      ordPdtItpCdN: "품종",
+      ordPdtItdsCdN: "품명",
+      adjustConsBktStartDttm: "ATP조정일",
+      customerNumber: "고객사코드",
+      customerName: "고객사명",
+      ordThwTapWekCd: "출강주",
+      orderType: "수주구분",
+      orderLineQty: "주문량",
+      orderThick: "두께",
+      orderWidth: "폭",
+      orderLength: "길이",
+      orderUsageCdN: "용도",
+      orderEdgeCode: "Edge",
+      stockCode: "제품재고판매",
+      salesPerson: "영업담당자",
+      salesCodeN: "판매특기",
+      salCusManDblTp: "판매고객사 대표산업",
+      salCusLocLClsTp: "판매고객사 지역대분류",
+      prodStdPackTolMin: "제품정포장하한중량",
+      prodStdPackTolMax: "제품정포장상한중량",
+      specificationCdN: "제품규격약호",
+      surfaceFinishCd: "표면지정코드",
+      postTreatmentMethodCdN: "후처리코드",
+      oilingMethodCd: "도유코드",
+      planningItemCodeN: "PlanningItem코드",
+      smSteelGrdN: "출강목표번호",
+      moltenSteelCharCdN: "용강특성",
+      tsAim: "목표TS",
+      unitWeight: "제품칫수계산단중",
+      hrSpComposite: "열연SkinPass합성지정",
+      surfaceGrd: "표면등급",
+      shapeGrd: "형상등급",
+      poscoProdGrdN: "제품사내보증번호",
+      hrProdThkAim: "열연목표두께",
+      hrProdWthAim: "열연목표폭",
+      hrRollUnitWgtMax: "압연상한중량",
+      sm2ndRfnCd: "제강2차정련코드",
+      skinpassFlag: "제품SkinPass지정여부",
+      packingType: "포장방법",
+      facAllocWgt: "소내공장결정중량",
+      faAllocDate: "생산가능공장결정일자",
+      errorMessage: "ErrorMessage",
+      msgcode: "박판공정계획Message코드",
+      lastUpdateDate: "최종수정일자",
+    };
+
+    const originalHeader = [
+      "gcsCompCode",
+      "millCd",
+      "orderHeadLineNo",
+      "creationDate",
+      "osMainStatusCd",
+      "faConfirmFlag",
+      "posbPassFacCdN",
+      "posbPassFacUpdateDate",
+      "cfirmPassOpCd",
+      "ordPdtItpCdN",
+      "ordPdtItdsCdN",
+      "adjustConsBktStartDttm",
+      "customerNumber",
+      "customerName",
+      "ordThwTapWekCd",
+      "orderType",
+      "orderLineQty",
+      "orderThick",
+      "orderWidth",
+      "orderLength",
+      "orderUsageCdN",
+      "orderEdgeCode",
+      "stockCode",
+      "salesPerson",
+      "salesCodeN",
+      "salCusManDblTp",
+      "salCusLocLClsTp",
+      "prodStdPackTolMin",
+      "prodStdPackTolMax",
+      "specificationCdN",
+      "surfaceFinishCd",
+      "postTreatmentMethodCdN",
+      "oilingMethodCd",
+      "planningItemCodeN",
+      "smSteelGrdN",
+      "moltenSteelCharCdN",
+      "tsAim",
+      "unitWeight",
+      "hrSpComposite",
+      "surfaceGrd",
+      "shapeGrd",
+      "poscoProdGrdN",
+      "hrProdThkAim",
+      "hrProdWthAim",
+      "hrRollUnitWgtMax",
+      "sm2ndRfnCd",
+      "skinpassFlag",
+      "packingType",
+      "facAllocWgt",
+      "faAllocDate",
+      "errorMessage",
+      "msgcode",
+      "lastUpdateDate",
+    ];
+
+    const sortedOrderList = [...orderList.list].sort((a, b) => a.id - b.id);
+    const excelData = sortedOrderList.map((item) =>
+      originalHeader.map((key) => item[key])
+    );
+    const koreanHeader = originalHeader.map(
+      (englishKey) => koreanHeaderMap[englishKey] || englishKey
+    );
+
     const fileType =
       "application/vnd.openxmlformats-officedcoument.spreadsheetml.sheet;charset=UTF-8";
     const fileExtension = ".xlsx";
-    const ws = XLSX.utils.json_to_sheet(orderList.list);
+
+    const ws = XLSX.utils.aoa_to_sheet([koreanHeader, ...excelData]);
+    // const ws = XLSX.utils.json_to_sheet(orderList.list);
     const wb = { Sheets: { data: ws }, SheetNames: ["data"] };
     const excelBuffer = XLSX.write(wb, { bookType: "xlsx", type: "array" });
     const data = new Blob([excelBuffer], { type: fileType });
@@ -238,7 +361,6 @@ const MainConfirm = ({ userData }) => {
       field: "gcsCompCode",
       headerName: "법인",
       width: 100,
-
       editable: false,
       headerAlign: "center",
     },
@@ -246,7 +368,6 @@ const MainConfirm = ({ userData }) => {
       field: "millCd",
       headerName: "소구분",
       width: 100,
-
       editable: false,
       headerAlign: "center",
     },
@@ -268,7 +389,6 @@ const MainConfirm = ({ userData }) => {
       field: "osMainStatusCd",
       headerName: "진도",
       width: 100,
-
       editable: false,
       headerAlign: "center",
     },

--- a/frontend/src/pages/main-confirm/index.js
+++ b/frontend/src/pages/main-confirm/index.js
@@ -208,14 +208,17 @@ const MainConfirm = ({ userData }) => {
 
     await MainApi.confirmDecision(userData.name, selectedIdList, (data) => {
       const res = data.response;
-      Notify.success(res.success + "/" + allCnt + "건 성공", {
-        showOnlyTheLastOne: false,
-      });
-      Notify.failure(res.fail + "/" + allCnt + "건 실패", {
-        showOnlyTheLastOne: false,
-      });
 
-      setRowSelectionModel([]);
+      if (res.success > 0) {
+        Notify.success(res.success + "건 성공", {
+          showOnlyTheLastOne: false,
+        });
+      }
+      if (res.fail > 0) {
+        Notify.failure(res.fail + "건 실패", {
+          showOnlyTheLastOne: false,
+        });
+      }
 
       /** 리스트 update */
       getOrders(codeNameList.select, weekList.select);

--- a/frontend/src/pages/main-confirm/index.js
+++ b/frontend/src/pages/main-confirm/index.js
@@ -771,7 +771,7 @@ const MainConfirm = ({ userData }) => {
                   setFlag(["D", "E"]);
                 }}
               >
-                ALL
+                All
               </MenuItem>
               <MenuItem
                 value={1}

--- a/frontend/src/views/log/possible-modal.js
+++ b/frontend/src/views/log/possible-modal.js
@@ -72,6 +72,7 @@ function Row(props) {
                     "& .MuiTableCell-head": {
                       border: "1px solid rgba(225, 234, 239, 1)",
                       fontSize: 14,
+                      backgroundColor: "#F9FAFC",
                     },
                   }}
                 >

--- a/frontend/src/views/main-capacity/capacity-detail.js
+++ b/frontend/src/views/main-capacity/capacity-detail.js
@@ -113,68 +113,42 @@ const CapacityDetail = (props) => {
         /> */}
           <Card>
             <TableContainer component={Paper}>
-              <Table sx={{ minWidth: 700 }} aria-label="spanning table">
+              <Table
+                sx={{
+                  minWidth: 700,
+                  "& .MuiTableCell-head, & .css-1det703-MuiTableBody-root": {
+                    fontSize: 17,
+                  },
+                }}
+                aria-label="spanning table"
+              >
                 <TableHead>
                   <TableRow>
-                    <TableCell
-                      rowSpan={2}
-                      align="center"
-                      style={{ fontSize: 17 }}
-                    >
+                    <TableCell rowSpan={2} align="center">
                       적용
                     </TableCell>
-                    <TableCell
-                      colSpan={2}
-                      align="center"
-                      style={{ fontSize: 17 }}
-                    >
+                    <TableCell colSpan={2} align="center">
                       제강
                     </TableCell>
-                    <TableCell
-                      colSpan={2}
-                      align="center"
-                      style={{ fontSize: 17 }}
-                    >
+                    <TableCell colSpan={2} align="center">
                       열연
                     </TableCell>
-                    <TableCell
-                      colSpan={2}
-                      align="center"
-                      style={{ fontSize: 17 }}
-                    >
+                    <TableCell colSpan={2} align="center">
                       열연정정
                     </TableCell>
-                    <TableCell
-                      colSpan={3}
-                      align="center"
-                      style={{ fontSize: 17 }}
-                    >
+                    <TableCell colSpan={3} align="center">
                       냉간압연
                     </TableCell>
-                    <TableCell
-                      colSpan={3}
-                      align="center"
-                      style={{ fontSize: 17 }}
-                    >
+                    <TableCell colSpan={3} align="center">
                       1차소둔
                     </TableCell>
-                    <TableCell
-                      colSpan={2}
-                      align="center"
-                      style={{ fontSize: 17 }}
-                    >
+                    <TableCell colSpan={2} align="center">
                       2차소둔
                     </TableCell>
-                    <TableCell
-                      colSpan={2}
-                      align="center"
-                      style={{ fontSize: 17 }}
-                    >
+                    <TableCell colSpan={2} align="center">
                       도금
                     </TableCell>
-                    <TableCell align="center" style={{ fontSize: 17 }}>
-                      정정
-                    </TableCell>
+                    <TableCell align="center">정정</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell align="center">1</TableCell>

--- a/frontend/src/views/main-capacity/capacity-detail.js
+++ b/frontend/src/views/main-capacity/capacity-detail.js
@@ -11,25 +11,6 @@ import TableHead from "@mui/material/TableHead";
 import Paper from "@mui/material/Paper";
 
 const CapacityDetail = (props) => {
-  const [order, setOrder] = useState({
-    id: 0,
-    orderHeadLineNo: null,
-    posbPassFacUpdateDate: null,
-    posbPassFacCdN: null,
-  });
-
-  useEffect(async () => {
-    // await MainCapacityApi.getOrder(props.order.id, (data) => {
-    //   const order = data.response;
-    //   setOrder({
-    //     id: order.id,
-    //     orderHeadLineNo: order.orderHeadLineNo,
-    //     posbPassFacUpdateDate: order.posbPassFacUpdateDate,
-    //     posbPassFacCdN: order.posbPassFacCdN,
-    //   });
-    // });
-  }, [props.order]);
-
   return (
     <>
       <div
@@ -56,19 +37,14 @@ const CapacityDetail = (props) => {
               <Table
                 aria-label="custom pagination table"
                 style={{
-                  display: "flex",
-                  flexDirection: "row",
-                  justifyContent: "space-evenly",
                   backgroundColor: "#FFFFFF",
                 }}
               >
-                <TableBody
-                // style={{ border: "1px solid #8E8E8E" }}
-                >
-                  <TableRow key="1" style={{ padding: 0 }}>
+                <TableBody>
+                  <TableRow>
                     <TableCell
                       style={{
-                        width: 160,
+                        width: "14%",
                         backgroundColor: "#0A5380",
                         color: "#FFFFFF",
                       }}
@@ -77,14 +53,14 @@ const CapacityDetail = (props) => {
                       주문번호
                     </TableCell>
                     <TableCell
-                      style={{ width: 200, color: "000000" }}
+                      style={{ width: "21%", color: "000000" }}
                       align="center"
                     >
                       {props.order.orderHeadLineNo}
                     </TableCell>
                     <TableCell
                       style={{
-                        width: 160,
+                        width: "14%",
                         backgroundColor: "#0A5380",
                         color: "#FFFFFF",
                       }}
@@ -93,14 +69,14 @@ const CapacityDetail = (props) => {
                       설계 일시
                     </TableCell>
                     <TableCell
-                      style={{ width: 200, color: "000000" }}
+                      style={{ width: "18%", color: "000000" }}
                       align="center"
                     >
                       {props.order.posbPassFacUpdateDate}
                     </TableCell>
                     <TableCell
                       style={{
-                        width: 160,
+                        width: "14%",
                         backgroundColor: "#0A5380",
                         color: "#FFFFFF",
                       }}
@@ -109,7 +85,7 @@ const CapacityDetail = (props) => {
                       설계 결과
                     </TableCell>
                     <TableCell
-                      style={{ width: 200, color: "000000" }}
+                      style={{ width: "19%", color: "000000" }}
                       align="center"
                     >
                       {props.order.posbPassFacCdN}

--- a/frontend/src/views/main-confirm/factory-detail.js
+++ b/frontend/src/views/main-confirm/factory-detail.js
@@ -79,39 +79,40 @@ const FactoryDetail = (props) => {
 
   return (
     <>
-      {/* order: {props.order.id} :{props.factory.code} */}
-      <Card style={{ marginBottom: 20 }}>
+      <Card style={{ marginBottom: 10 }}>
         <TableContainer
-          style={{
-            // background: "#FFFFFF",
-            display: "flex",
-            flexDirection: "row",
-          }}
+          style={
+            {
+              // background: "#FFFFFF",
+              // display: "flex",
+              // flexDirection: "row",
+            }
+          }
         >
-          <Table aria-label="spanning table">
-            <TableHead>
+          <Table aria-label="custom pagination table">
+            <TableBody>
               <TableRow>
                 <TableCell
                   align="center"
                   style={{
-                    width: "40%",
+                    width: 140,
                     backgroundColor: "#0A5380",
                     color: "#FFFFFF",
-                    fontSize: 17,
+                    whiteSpace: "nowrap",
                   }}
                 >
                   공정
                 </TableCell>
-                <TableCell align="center" style={{ fontSize: 17 }}>
-                  {props.factory.name}
-                </TableCell>
+                <TableCell align="center">{props.factory.name}</TableCell>
               </TableRow>
-            </TableHead>
+            </TableBody>
           </Table>
         </TableContainer>
       </Card>
       <Card>
-        <TableContainer>
+        <TableContainer
+          sx={{ "& .css-1nrlq1o-MuiFormControl-root": { display: "flex" } }}
+        >
           <FormControl>
             <RadioGroup
               aria-labelledby="demo-radio-buttons-group-label"
@@ -120,42 +121,18 @@ const FactoryDetail = (props) => {
             >
               <Table aria-label="spanning table">
                 <TableHead>
-                  <TableRow>
-                    <TableCell
-                      align="center"
-                      style={{
+                  <TableRow
+                    sx={{
+                      "& .MuiTableCell-head": {
                         fontSize: 17,
                         whiteSpace: "nowrap",
-                      }}
-                    >
-                      공장
-                    </TableCell>
-                    <TableCell
-                      align="center"
-                      style={{
-                        fontSize: 17,
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      능력 여유량
-                    </TableCell>
-                    <TableCell
-                      align="center"
-                      style={{
-                        fontSize: 17,
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      능력 사용량
-                    </TableCell>
-                    <TableCell
-                      align="center"
-                      style={{
-                        fontSize: 17,
-                      }}
-                    >
-                      선택
-                    </TableCell>
+                      },
+                    }}
+                  >
+                    <TableCell align="center">공장</TableCell>
+                    <TableCell align="center">능력 여유량</TableCell>
+                    <TableCell align="center">능력 사용량</TableCell>
+                    <TableCell align="center">선택</TableCell>
                   </TableRow>
                 </TableHead>
 
@@ -178,11 +155,6 @@ const FactoryDetail = (props) => {
                             : ""}
                         </TableCell>
                         <TableCell>
-                          {/* <Checkbox
-                          checked={
-                            props.factory.code == f.firmPsFacTp ? true : false
-                          }
-                        /> */}
                           <FormControlLabel
                             value={f.firmPsFacTp}
                             onChange={() => {

--- a/frontend/src/views/main-confirm/factory-detail.js
+++ b/frontend/src/views/main-confirm/factory-detail.js
@@ -80,15 +80,7 @@ const FactoryDetail = (props) => {
   return (
     <>
       <Card style={{ marginBottom: 10 }}>
-        <TableContainer
-          style={
-            {
-              // background: "#FFFFFF",
-              // display: "flex",
-              // flexDirection: "row",
-            }
-          }
-        >
+        <TableContainer>
           <Table aria-label="custom pagination table">
             <TableBody>
               <TableRow>

--- a/frontend/src/views/main-confirm/order-detail.js
+++ b/frontend/src/views/main-confirm/order-detail.js
@@ -12,7 +12,7 @@ const OrderDetail = (props) => {
   const [cfCode, setCfCode] = useState("");
   const [factory, setFactory] = useState({
     no: "10",
-    name: "제강",
+    name: props.order.cfirmPassOpCd == null ? "" : "제강",
     code:
       props.order.cfirmPassOpCd == null
         ? null
@@ -20,14 +20,20 @@ const OrderDetail = (props) => {
   });
 
   useEffect(() => {
-    if (props.order.cfirmPassOpCd != null) {
-      setCfCode(props.order.cfirmPassOpCd.padEnd(8, " "));
-    }
+    // if (props.order.cfirmPassOpCd != null) {
+    //   setCfCode(props.order.cfirmPassOpCd.padEnd(8, " "));
+    // }
+    setCfCode(
+      props.order.cfirmPassOpCd != null
+        ? props.order.cfirmPassOpCd.padEnd(8, " ")
+        : ""
+    );
+
     setFactory((prev) => {
       return {
         ...prev,
-        no: "10",
-        name: "제강",
+        no: props.order.cfirmPassOpCd == null ? " " : "10",
+        name: props.order.cfirmPassOpCd == null ? "" : "제강",
         code:
           props.order.cfirmPassOpCd == null
             ? null
@@ -72,23 +78,19 @@ const OrderDetail = (props) => {
         >
           <div style={{ marginRight: "20px", height: "200px" }}>
             {/* <Card style={{ marginRight: "20px", height: "200px" }}> */}
-            <Card style={{ marginBottom: 20 }}>
+            <Card style={{ marginBottom: 10 }}>
               <TableContainer>
                 <Table
                   aria-label="custom pagination table"
                   style={{
-                    display: "flex",
-                    flexDirection: "row",
                     backgroundColor: "#FFFFFF",
-                    // justifyContent: "space-between",
                   }}
-                  // component={Paper}
                 >
-                  <TableBody>
-                    <TableRow>
+                  <TableBody style={{ width: "100%" }}>
+                    <TableRow style={{ width: "100%" }}>
                       <TableCell
                         style={{
-                          width: 160,
+                          width: "14%",
                           backgroundColor: "#0A5380",
                           color: "#FFFFFF",
                         }}
@@ -98,7 +100,7 @@ const OrderDetail = (props) => {
                       </TableCell>
                       <TableCell
                         style={{
-                          width: 200,
+                          width: "24%",
                           color: "000000",
                         }}
                         align="center"
@@ -107,7 +109,7 @@ const OrderDetail = (props) => {
                       </TableCell>
                       <TableCell
                         style={{
-                          width: 160,
+                          width: "14%",
                           backgroundColor: "#0A5380",
                           color: "#FFFFFF",
                         }}
@@ -116,14 +118,14 @@ const OrderDetail = (props) => {
                         주문량
                       </TableCell>
                       <TableCell
-                        style={{ width: 200, color: "000000" }}
+                        style={{ width: "17%", color: "000000" }}
                         align="center"
                       >
                         {props.order.orderLineQty}
                       </TableCell>
                       <TableCell
                         style={{
-                          width: 160,
+                          width: "14%",
                           backgroundColor: "#0A5380",
                           color: "#FFFFFF",
                         }}
@@ -132,10 +134,12 @@ const OrderDetail = (props) => {
                         설계 결과
                       </TableCell>
                       <TableCell
-                        style={{ width: 200, color: "000000" }}
+                        style={{ width: "17%", color: "000000" }}
                         align="center"
                       >
-                        {props.order.cfirmPassOpCd}
+                        {props.order.cfirmPassOpCd == null
+                          ? " "
+                          : props.order.cfirmPassOpCd}
                       </TableCell>
                     </TableRow>
                   </TableBody>
@@ -169,7 +173,7 @@ const OrderDetail = (props) => {
                           changeFactory(e, cfCode.charAt(0));
                         }}
                         style={{
-                          color: `${factory.no == 10 ? "darkred" : ""}`,
+                          color: `${factory.no === "10" ? "darkred" : ""}`,
                         }}
                       >
                         제강
@@ -181,7 +185,7 @@ const OrderDetail = (props) => {
                           changeFactory(e, cfCode.charAt(1));
                         }}
                         style={{
-                          color: `${factory.no == 20 ? "darkred" : ""}`,
+                          color: `${factory.no === "20" ? "darkred" : ""}`,
                         }}
                       >
                         열연
@@ -193,7 +197,7 @@ const OrderDetail = (props) => {
                           changeFactory(e, cfCode.charAt(2));
                         }}
                         style={{
-                          color: `${factory.no == 30 ? "darkred" : ""}`,
+                          color: `${factory.no === "30" ? "darkred" : ""}`,
                         }}
                       >
                         열연정정
@@ -205,7 +209,7 @@ const OrderDetail = (props) => {
                           changeFactory(e, cfCode.charAt(3));
                         }}
                         style={{
-                          color: `${factory.no == 40 ? "darkred" : ""}`,
+                          color: `${factory.no === "40" ? "darkred" : ""}`,
                         }}
                       >
                         냉간압연
@@ -217,7 +221,7 @@ const OrderDetail = (props) => {
                           changeFactory(e, cfCode.charAt(4));
                         }}
                         style={{
-                          color: `${factory.no == 50 ? "darkred" : ""}`,
+                          color: `${factory.no === "50" ? "darkred" : ""}`,
                         }}
                       >
                         1차소둔
@@ -229,7 +233,7 @@ const OrderDetail = (props) => {
                           changeFactory(e, cfCode.charAt(5));
                         }}
                         style={{
-                          color: `${factory.no == 60 ? "darkred" : ""}`,
+                          color: `${factory.no === "60" ? "darkred" : ""}`,
                         }}
                       >
                         2차소둔
@@ -241,7 +245,7 @@ const OrderDetail = (props) => {
                           changeFactory(e, cfCode.charAt(6));
                         }}
                         style={{
-                          color: `${factory.no == 70 ? "darkred" : ""}`,
+                          color: `${factory.no === "70" ? "darkred" : ""}`,
                         }}
                       >
                         도금
@@ -253,7 +257,7 @@ const OrderDetail = (props) => {
                           changeFactory(e, cfCode.charAt(7));
                         }}
                         style={{
-                          color: `${factory.no == 80 ? "darkred" : ""}`,
+                          color: `${factory.no === "80" ? "darkred" : ""}`,
                         }}
                       >
                         정정


### PR DESCRIPTION
### 목적

- 가통설계, 공장결정, 로그 페이지 QA
  
### 주요 변경사항
  
- [x] [로그] 카드 단차 수정
- [x] [로그] 가통상세 테이블 헤더 색상 추가
- [x] [가통설계, 공장결정] 상세 테이블 CSS 수정
- [x] [가통설계, 공장결정] ALL -> All로 수정
- [x] [가통설계, 공장결정] excel export 시 컬럼명 한글 반영
- [x] [가통설계, 공장결정] 설계 후 성공 or 실패만 했을 때 Alert창 한개만 보이도록
- [x] [가통설계, 공장결정] 여러 주문 선택하여 설계 시 에러 발생한 row 빼고 dataGrid의 체크박스에 반영되도록, 공장결정은 설계 주문건 그대로 남아있도록 수정
- [x] [공장결정, 투입능력] 공장결정 시 해당 주문 출강주의 능력 데이터 없는 경우, 투입능력 페이지로 넘어갈 때 능력데이터 없는 출강주 자동 선택되어 있도록 수정 
