### PR TITLE
[fix] 공장변경 후 선택된 주문 유지

### DIFF
--- a/frontend/src/pages/main-confirm/index.js
+++ b/frontend/src/pages/main-confirm/index.js
@@ -94,14 +94,18 @@ const MainConfirm = ({ userData }) => {
     });
   }, []);
 
-  const getOrders = (kind, week) => {
+  const getOrders = (kind, week, selectedOrderId) => {
     if (kind == 0) kind = null;
     if (week == 0) week = null;
+
     MainApi.getOrderList(kind, week, osMainStatusCd, flag, (data) => {
       const list = data.response;
-      const order = list[0];
-      // console.log(list);
-      // console.log(order);
+      const order = {};
+      if (selectedOrderId == undefined) order = list[0];
+      else {
+        order = list.find((obj) => obj.id === selectedOrderId);
+      }
+
       setOrderList((prev) => {
         return { ...prev, list, order };
       });

--- a/frontend/src/views/main-confirm/factory-detail.js
+++ b/frontend/src/views/main-confirm/factory-detail.js
@@ -15,13 +15,19 @@ import TableRow from "@mui/material/TableRow";
 import TableHead from "@mui/material/TableHead";
 import MainApi from "src/pages/api/pofect/MainApi";
 import { Notify } from "src/notifix/notiflix-notify-aio";
+import withAuth from "src/pages/api/auth/withAuth";
+import { useSession } from "next-auth/react";
 
 const FactoryDetail = (props) => {
+  const { data: session } = useSession();
+  const reversedName = session.user.name.split(" ").reverse().join("");
+
   const [factoryList, setFactoryList] = useState({
     list: [],
   });
   const [selectedFac, setSelectedFac] = useState(null);
   const [changeData, setChangeData] = useState({
+    userName: "",
     orderId: 0,
     processCd: "",
     prevFactory: "",
@@ -34,6 +40,7 @@ const FactoryDetail = (props) => {
     setChangeData((prev) => {
       return {
         ...prev,
+        userName: reversedName,
         orderId: props.order.id,
         processCd: props.factory.no,
         prevFactory: props.factory.code,
@@ -53,7 +60,6 @@ const FactoryDetail = (props) => {
   }, [props.factory, props.order]);
 
   const handleFactory = (facNo) => {
-    console.log(facNo);
     setSelectedFac(facNo);
 
     setChangeData((prev) => {
@@ -68,12 +74,10 @@ const FactoryDetail = (props) => {
     // 이전 값이랑 같으면 pass
     if (props.factory.code == selectedFac) return;
 
-    console.log(changeData);
-
     MainApi.changeFactory(changeData, (data) => {
       const res = data.response;
       Notify.success("변경되었습니다.");
-      props.getOrder(null, null);
+      props.getOrder(null, null, props.order.id);
     });
   };
 
@@ -184,4 +188,4 @@ const FactoryDetail = (props) => {
     </>
   );
 };
-export default FactoryDetail;
+export default withAuth(FactoryDetail, { userData: true });


### PR DESCRIPTION
### 목적

- 공장변경 후 선택된 주문 유지
  
### 주요 변경사항
  
- [x] 공장변경 후 상세 페이지 주문이 전체 주문 리스트의 첫번째 주문으로 돌아가는 오류 해결
